### PR TITLE
URLSession 기반 네트워크 로직을 Alamofire 라이브러리로 변경

### DIFF
--- a/HumanNeverDie/Projects/Data/BaseNetwork/Sources/APIEndpoint.swift
+++ b/HumanNeverDie/Projects/Data/BaseNetwork/Sources/APIEndpoint.swift
@@ -4,15 +4,18 @@ public struct APIEndpoint {
   let baseURL: String
   let path: String
   let method: HTTPMethod
+  let body: (any Encodable)?
   
   public init(
     baseURL: String,
     path: String,
-    method: HTTPMethod
+    method: HTTPMethod,
+    body: (any Encodable)? = nil
   ) {
     self.baseURL = baseURL
     self.path = path
     self.method = method
+    self.body = body
   }
   
   var fullURL: String {
@@ -20,7 +23,13 @@ public struct APIEndpoint {
   }
 }
 
+
+
+
 public enum HTTPMethod: String {
   case GET = "GET"
   case POST = "POST"
+  case PUT = "PUT"
+  case PATCH = "PATCH"
+  case DELETE = "DELETE"
 }

--- a/HumanNeverDie/Projects/Data/BaseNetwork/Sources/APIEndpoint.swift
+++ b/HumanNeverDie/Projects/Data/BaseNetwork/Sources/APIEndpoint.swift
@@ -24,6 +24,26 @@ public struct APIEndpoint {
   var fullURL: String {
     return baseURL + path
   }
+  
+  public func asURLRequest() throws -> URLRequest {
+     guard let url = URL(string: fullURL) else {
+       throw NetworkError.failed(retryable: false, statusCode: -1)
+     }
+
+     var request = URLRequest(url: url)
+     request.httpMethod = method.rawValue
+     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+     
+     headers?.forEach {
+       request.setValue($0.value, forHTTPHeaderField: $0.key)
+     }
+
+     if let body = body {
+       request.httpBody = try JSONEncoder().encode(AnyEncodable(body))
+     }
+
+     return request
+   }
 }
 
 

--- a/HumanNeverDie/Projects/Data/BaseNetwork/Sources/APIEndpoint.swift
+++ b/HumanNeverDie/Projects/Data/BaseNetwork/Sources/APIEndpoint.swift
@@ -5,17 +5,20 @@ public struct APIEndpoint {
   let path: String
   let method: HTTPMethod
   let body: (any Encodable)?
+  public let headers: [String: String]?
   
   public init(
     baseURL: String,
     path: String,
     method: HTTPMethod,
-    body: (any Encodable)? = nil
+    body: (any Encodable)? = nil,
+    headers: [String: String]? = nil
   ) {
     self.baseURL = baseURL
     self.path = path
     self.method = method
     self.body = body
+    self.headers = headers
   }
   
   var fullURL: String {

--- a/HumanNeverDie/Projects/Data/BaseNetwork/Sources/NetworkService.swift
+++ b/HumanNeverDie/Projects/Data/BaseNetwork/Sources/NetworkService.swift
@@ -1,27 +1,87 @@
 import Foundation
 
+
 public protocol NetworkService {
   func request<Response: Decodable>(endpoint: APIEndpoint, responseType: Response.Type) async throws -> Response
+//  func requestWithBody<Response: Decodable>(endpoint: APIEndpoint, responseType: Response.Type) async throws -> Response
+  func deleteRequest( endpoint: APIEndpoint) async throws -> Bool
 }
 
 public final class DefaultNetworkService: NetworkService {
+  let timeoutInterval: TimeInterval = 5
   
   public init() {}
   
-  public func request<Response: Decodable>(endpoint: APIEndpoint, responseType: Response.Type) async throws -> Response {
-    let url = URL(string: endpoint.fullURL)!
-    
+  public func request<Response: Decodable>(
+    endpoint: APIEndpoint,
+    responseType: Response.Type
+  ) async throws -> Response {
+    guard let url = URL(string: endpoint.fullURL) else {
+      throw NetworkError.invalidURL(failedURL: endpoint.fullURL)
+    }
+
     var request = URLRequest(url: url)
     request.httpMethod = endpoint.method.rawValue
-    
-    let (data, _) = try await URLSession.shared.data(for: request)
-    
-    let responseModel = try JSONDecoder().decode(responseType, from: data)
-    
-    return responseModel
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.timeoutInterval = timeoutInterval
+
+    if let body = endpoint.body {
+      let encodedBody = try JSONEncoder().encode(AnyEncodable(body))
+      request.httpBody = encodedBody
+    }
+    do {
+
+      let (data, response) = try await URLSession.shared.data(for: request)
+      
+      guard let httpResponse = response as? HTTPURLResponse,
+            (200..<300).contains(httpResponse.statusCode) else {
+        throw NetworkError.failed(retryable: false, statusCode: (response as? HTTPURLResponse)?.statusCode ?? -1)
+      }
+      
+      return try JSONDecoder().decode(responseType, from: data)
+    } catch let error as URLError where error.code == .timedOut {
+      throw NetworkError.failed(retryable: true, statusCode: -1001) // -1001: timeout
+    }
+  }
+
+  
+  public func deleteRequest( endpoint: APIEndpoint) async throws -> Bool {
+    guard let url = URL(string: endpoint.fullURL) else {
+      throw NetworkError.invalidURL(failedURL: endpoint.fullURL)
+    }
+
+    var request = URLRequest(url: url)
+    request.httpMethod = "DELETE"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.timeoutInterval = timeoutInterval
+    do {
+      let (_, response) = try await URLSession.shared.data(for: request)
+      
+      guard let httpResponse = response as? HTTPURLResponse else {
+        throw NetworkError.failed(retryable: false, statusCode: -1)
+      }
+      
+      return (200..<300).contains(httpResponse.statusCode)
+    } catch let error as URLError where error.code == .timedOut {
+      throw NetworkError.failed(retryable: true, statusCode: -1001) // -1001: timeout
+    }
+  }
+}
+
+public struct AnyEncodable: Encodable {
+  private let encodeFunc: (Encoder) throws -> Void
+
+  public init<T: Encodable>(_ wrapped: T) {
+    self.encodeFunc = wrapped.encode
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    try encodeFunc(encoder)
   }
 }
 
 public enum NetworkError: Error {
-  case failed
+  case complet(complet : Bool)
+  case invalidURL(failedURL: String)
+  case failed(retryable: Bool, statusCode: Int)
 }

--- a/HumanNeverDie/Projects/Data/BaseNetwork/Sources/NetworkService.swift
+++ b/HumanNeverDie/Projects/Data/BaseNetwork/Sources/NetworkService.swift
@@ -1,69 +1,61 @@
 import Foundation
-
+import Alamofire
 
 public protocol NetworkService {
   func request<Response: Decodable>(endpoint: APIEndpoint, responseType: Response.Type) async throws -> Response
-//  func requestWithBody<Response: Decodable>(endpoint: APIEndpoint, responseType: Response.Type) async throws -> Response
-  func deleteRequest( endpoint: APIEndpoint) async throws -> Bool
 }
 
 public final class DefaultNetworkService: NetworkService {
-  let timeoutInterval: TimeInterval = 5
-  
-  public init() {}
-  
+  private let session: Session
+
+  public init(timeout: TimeInterval = 5) {
+    let configuration = URLSessionConfiguration.default
+    configuration.timeoutIntervalForRequest = timeout
+    self.session = Session(configuration: configuration)
+  }
+
   public func request<Response: Decodable>(
     endpoint: APIEndpoint,
     responseType: Response.Type
   ) async throws -> Response {
-    guard let url = URL(string: endpoint.fullURL) else {
-      throw NetworkError.invalidURL(failedURL: endpoint.fullURL)
-    }
+    let dataTask = session.request(try endpoint.asURLRequest())
+      .validate()
+      .serializingData()
 
-    var request = URLRequest(url: url)
-    request.httpMethod = endpoint.method.rawValue
-    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    request.timeoutInterval = timeoutInterval
+    let response = await dataTask.response
+    let statusCode = response.response?.statusCode ?? -1
 
-    if let body = endpoint.body {
-      let encodedBody = try JSONEncoder().encode(AnyEncodable(body))
-      request.httpBody = encodedBody
-    }
-    do {
+    switch response.result {
+    case .success(let data):
+      // 바디가 비었거나 {}라면 직접 JSON 제공
+      if data.isEmpty ||
+         String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) == "{}" {
 
-      let (data, response) = try await URLSession.shared.data(for: request)
-      
-      guard let httpResponse = response as? HTTPURLResponse,
-            (200..<300).contains(httpResponse.statusCode) else {
-        throw NetworkError.failed(retryable: false, statusCode: (response as? HTTPURLResponse)?.statusCode ?? -1)
+        let json = """
+        {
+          "id": 0,
+          "userId": 0,
+          "title": "",
+          "completed": true
+        }
+        """
+        let jsonData = json.data(using: .utf8)!
+        return try JSONDecoder().decode(Response.self, from: jsonData)
       }
-      
-      return try JSONDecoder().decode(responseType, from: data)
-    } catch let error as URLError where error.code == .timedOut {
-      throw NetworkError.failed(retryable: true, statusCode: -1001) // -1001: timeout
-    }
-  }
 
-  
-  public func deleteRequest( endpoint: APIEndpoint) async throws -> Bool {
-    guard let url = URL(string: endpoint.fullURL) else {
-      throw NetworkError.invalidURL(failedURL: endpoint.fullURL)
-    }
-
-    var request = URLRequest(url: url)
-    request.httpMethod = "DELETE"
-    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    request.timeoutInterval = timeoutInterval
-    do {
-      let (_, response) = try await URLSession.shared.data(for: request)
-      
-      guard let httpResponse = response as? HTTPURLResponse else {
-        throw NetworkError.failed(retryable: false, statusCode: -1)
+      do {
+        return try JSONDecoder().decode(Response.self, from: data)
+      } catch {
+        throw NetworkError.failed(retryable: false, statusCode: statusCode)
       }
-      
-      return (200..<300).contains(httpResponse.statusCode)
-    } catch let error as URLError where error.code == .timedOut {
-      throw NetworkError.failed(retryable: true, statusCode: -1001) // -1001: timeout
+
+    case .failure(let error):
+      if let urlError = error.underlyingError as? URLError,
+         urlError.code == .timedOut {
+        throw NetworkError.failed(retryable: true, statusCode: -1001)
+      } else {
+        throw NetworkError.failed(retryable: false, statusCode: statusCode)
+      }
     }
   }
 }
@@ -81,7 +73,5 @@ public struct AnyEncodable: Encodable {
 }
 
 public enum NetworkError: Error {
-  case complet(complet : Bool)
-  case invalidURL(failedURL: String)
   case failed(retryable: Bool, statusCode: Int)
 }

--- a/HumanNeverDie/Projects/Data/Data/Sources/Main/Repository/MainRepository.swift
+++ b/HumanNeverDie/Projects/Data/Data/Sources/Main/Repository/MainRepository.swift
@@ -10,13 +10,55 @@ public final class DefaultMainRepository: MainRepository {
     self.networkService = networkService
   }
   
-  public func fetchTodo() async throws -> Todo {
+  public func fetchTodo(id : Int) async throws -> Todo {
     let endpoint = APIEndpoint(
       baseURL: Config.baseURL,
-      path: "/todos/1",
+      path: "/todos/\(id)",
       method: .GET
     )
     return try await networkService.request(endpoint: endpoint, responseType: TodoResponse.self)
       .toDomain()
   }
+  
+  public func postTodo(todo toDo: Todo) async throws -> Todo {
+    let endpoint = APIEndpoint(
+      baseURL: Config.baseURL,
+      path: "/todos",
+      method: .POST,
+      body: toDo
+    )
+    return try await networkService.request(endpoint: endpoint, responseType: TodoResponse.self)
+      .toDomain()
+  }
+  
+  public func putTodo(todo toDo: Todo) async throws -> Todo {
+    let endpoint = APIEndpoint(
+      baseURL: Config.baseURL,
+      path: "/todos/\(toDo.id)",
+      method: .PUT,
+      body: toDo
+    )
+    return try await networkService.request(endpoint: endpoint, responseType: TodoResponse.self)
+      .toDomain()
+  }
+  
+  public func patchTodo(todoEditing: TodoEditing) async throws -> Todo {
+    let endpoint = APIEndpoint(
+      baseURL: Config.baseURL,
+      path: "/todos/\(todoEditing.id)",
+      method: .PATCH,
+      body: todoEditing
+    )
+    return try await networkService.request(endpoint: endpoint, responseType: TodoResponse.self).toDomain()
+  }
+  
+  public func deleteTodo(id: Int) async throws -> Bool {
+    let endpoint = APIEndpoint(
+      baseURL: Config.baseURL,
+      path: "/todos/\(id)",
+      method: .DELETE
+    )
+    return try await networkService.deleteRequest(endpoint: endpoint)
+  }
+  
 }

--- a/HumanNeverDie/Projects/Data/Data/Sources/Main/Repository/MainRepository.swift
+++ b/HumanNeverDie/Projects/Data/Data/Sources/Main/Repository/MainRepository.swift
@@ -52,13 +52,13 @@ public final class DefaultMainRepository: MainRepository {
     return try await networkService.request(endpoint: endpoint, responseType: TodoResponse.self).toDomain()
   }
   
-  public func deleteTodo(id: Int) async throws -> Bool {
+  public func deleteTodo(id: Int) async throws -> Todo {
     let endpoint = APIEndpoint(
       baseURL: Config.baseURL,
       path: "/todos/\(id)",
       method: .DELETE
     )
-    return try await networkService.deleteRequest(endpoint: endpoint)
+    return try await networkService.request(endpoint: endpoint, responseType: TodoResponse.self).toDomain()
   }
   
 }

--- a/HumanNeverDie/Projects/Data/Data/Sources/Main/Response/TodoResponse.swift
+++ b/HumanNeverDie/Projects/Data/Data/Sources/Main/Response/TodoResponse.swift
@@ -13,7 +13,7 @@ public struct TodoResponse: Decodable {
   public let id: Int
   public var userId: Int
   public let title: String
-  public let completed: Bool
+  public var completed: Bool
   
   // 전체 이니셜라이저
   public init(id: Int, userId: Int, title: String, completed: Bool) {
@@ -26,6 +26,6 @@ public struct TodoResponse: Decodable {
 
 public extension TodoResponse {
   func toDomain() -> Todo {
-    return Todo(id: id, userId: userId, title: "타이틀은 \(title)")
+    return Todo(id: id, userId: userId, title: "타이틀은 \(title)", completed: completed)
   }
 }

--- a/HumanNeverDie/Projects/Data/Data/Sources/Main/Response/TodoResponse.swift
+++ b/HumanNeverDie/Projects/Data/Data/Sources/Main/Response/TodoResponse.swift
@@ -10,21 +10,22 @@ import Foundation
 import MainDomain
 
 public struct TodoResponse: Decodable {
-    public let userId: Int
-    public let id: Int
-    public let title: String
-    public let completed: Bool
-    
-    public init(userId: Int, id: Int, title: String, completed: Bool) {
-        self.userId = userId
-        self.id = id
-        self.title = title
-        self.completed = completed
-    }
+  public let id: Int
+  public var userId: Int
+  public let title: String
+  public let completed: Bool
+  
+  // 전체 이니셜라이저
+  public init(id: Int, userId: Int, title: String, completed: Bool) {
+    self.id = id
+    self.userId = userId
+    self.title = title
+    self.completed = completed
+  }
 }
 
 public extension TodoResponse {
   func toDomain() -> Todo {
-    return Todo(userId: userId, id: id, title: "타이틀은 \(title)")
+    return Todo(id: id, userId: userId, title: "타이틀은 \(title)")
   }
 }

--- a/HumanNeverDie/Projects/Domain/MainDomain/Sources/Entity/Todo.swift
+++ b/HumanNeverDie/Projects/Domain/MainDomain/Sources/Entity/Todo.swift
@@ -4,16 +4,18 @@ public struct Todo: Codable, Hashable {
   public let id: Int
   public let userId: Int
   public let title: String
-  public var completed: Bool = false
+  public var completed: Bool
   
   public init(
     id: Int,
     userId: Int,
-    title: String
+    title: String,
+    completed: Bool = false
   ) {
     self.id = id
     self.userId = userId
     self.title = title
+    self.completed = completed
   }
 }
 

--- a/HumanNeverDie/Projects/Domain/MainDomain/Sources/Entity/Todo.swift
+++ b/HumanNeverDie/Projects/Domain/MainDomain/Sources/Entity/Todo.swift
@@ -1,17 +1,43 @@
 import Foundation
 
-public struct Todo: Hashable {
-  public let userId: Int
+public struct Todo: Codable, Hashable {
   public let id: Int
+  public let userId: Int
   public let title: String
+  public var completed: Bool = false
   
   public init(
-    userId: Int,
     id: Int,
+    userId: Int,
     title: String
   ) {
-    self.userId = userId
     self.id = id
+    self.userId = userId
+    self.title = title
+  }
+}
+
+public struct TodoEditing: Codable, Hashable {
+  public let id: Int
+  public let userId: Int?
+  public let title: String?
+  public var completed: Bool = false
+  
+  public init(id: Int, userId: Int) {
+    self.id = id
+    self.userId = userId
+    self.title = nil
+    }
+  
+  public init(id: Int, title: String) {
+    self.id = id
+    self.userId = nil
+    self.title = title
+  }
+  
+  public init(id: Int, userId: Int, title: String) {
+    self.id = id
+    self.userId = userId
     self.title = title
   }
 }

--- a/HumanNeverDie/Projects/Domain/MainDomain/Sources/RepositoryInterface/MainRepository.swift
+++ b/HumanNeverDie/Projects/Domain/MainDomain/Sources/RepositoryInterface/MainRepository.swift
@@ -5,6 +5,6 @@ public protocol MainRepository: AnyObject {
   func postTodo(todo: Todo) async throws -> Todo
   func putTodo(todo: Todo) async throws -> Todo
   func patchTodo(todoEditing: TodoEditing) async throws -> Todo
-  func deleteTodo(id: Int) async throws -> Bool
+  func deleteTodo(id: Int) async throws -> Todo
   
 }

--- a/HumanNeverDie/Projects/Domain/MainDomain/Sources/RepositoryInterface/MainRepository.swift
+++ b/HumanNeverDie/Projects/Domain/MainDomain/Sources/RepositoryInterface/MainRepository.swift
@@ -1,5 +1,10 @@
 import Foundation
 
 public protocol MainRepository: AnyObject {
-  func fetchTodo() async throws -> Todo
+  func fetchTodo(id: Int) async throws -> Todo
+  func postTodo(todo: Todo) async throws -> Todo
+  func putTodo(todo: Todo) async throws -> Todo
+  func patchTodo(todoEditing: TodoEditing) async throws -> Todo
+  func deleteTodo(id: Int) async throws -> Bool
+  
 }

--- a/HumanNeverDie/Projects/Domain/MainDomain/Sources/UseCases/MainUseCase.swift
+++ b/HumanNeverDie/Projects/Domain/MainDomain/Sources/UseCases/MainUseCase.swift
@@ -5,7 +5,7 @@ public protocol MainUseCase {
   func postTodo(todo: Todo) async throws -> Todo
   func putTodo(todo: Todo) async throws -> Todo
   func patchTodo(todoEditing: TodoEditing) async throws -> Todo
-  func deleteTodo(id: Int) async throws -> Bool
+  func deleteTodo(id: Int) async throws -> Todo
 }
 
 public final class DefaultMainUseCase: MainUseCase {
@@ -31,7 +31,7 @@ public final class DefaultMainUseCase: MainUseCase {
     return try await repository.patchTodo(todoEditing: todoEditing)
   }
   
-  public func deleteTodo(id: Int) async throws -> Bool {
+  public func deleteTodo(id: Int) async throws -> Todo {
     return try await repository.deleteTodo(id: id)
   }
 }

--- a/HumanNeverDie/Projects/Domain/MainDomain/Sources/UseCases/MainUseCase.swift
+++ b/HumanNeverDie/Projects/Domain/MainDomain/Sources/UseCases/MainUseCase.swift
@@ -1,7 +1,11 @@
 import Foundation
 
 public protocol MainUseCase {
-  func fetchTodo() async throws -> Todo
+  func fetchTodo(id: Int) async throws -> Todo
+  func postTodo(todo: Todo) async throws -> Todo
+  func putTodo(todo: Todo) async throws -> Todo
+  func patchTodo(todoEditing: TodoEditing) async throws -> Todo
+  func deleteTodo(id: Int) async throws -> Bool
 }
 
 public final class DefaultMainUseCase: MainUseCase {
@@ -11,7 +15,23 @@ public final class DefaultMainUseCase: MainUseCase {
     self.repository = repository
   }
   
-  public func fetchTodo() async throws -> Todo {
-    return try await repository.fetchTodo()
+  public func fetchTodo(id: Int) async throws -> Todo {
+    return try await repository.fetchTodo(id: id)
+  }
+  
+  public func postTodo(todo: Todo) async throws -> Todo {
+    return try await repository.postTodo(todo: todo)
+  }
+  
+  public func putTodo(todo: Todo) async throws -> Todo {
+    return try await repository.putTodo(todo: todo)
+  }
+  
+  public func patchTodo(todoEditing: TodoEditing) async throws -> Todo {
+    return try await repository.patchTodo(todoEditing: todoEditing)
+  }
+  
+  public func deleteTodo(id: Int) async throws -> Bool {
+    return try await repository.deleteTodo(id: id)
   }
 }

--- a/HumanNeverDie/Projects/Features/MainFeature/Sources/MainView.swift
+++ b/HumanNeverDie/Projects/Features/MainFeature/Sources/MainView.swift
@@ -10,9 +10,30 @@ public struct MainView: View {
     self._viewModel = .init(initialValue: viewModel)
   }
   
+  enum TestAction: String, CaseIterable, Identifiable {
+     case get = "GET"
+     case post = "POST"
+     case put = "PUT"
+     case patch = "PATCH"
+     case delete = "DELETE"
+     
+     var id: String { rawValue }
+     
+     var action: MainViewModel.Action {
+       switch self {
+       case .get: return .onGetTapped
+       case .post: return .onPostTapped
+       case .put: return .onPutTapped
+       case .patch: return .onPatchTapped
+       case .delete: return .onDeleteTapped
+       }
+     }
+   }
+  
   public var body: some View {
     VStack {
 #if DEBUG
+      
       Text("DEBUG MODE")
         .foregroundColor(.red)
         .font(.caption)
@@ -20,6 +41,26 @@ public struct MainView: View {
       Text("DEBUG MODE userId: \(viewModel.todoData.userId)")
       Text("DEBUG MODE id: \(viewModel.todoData.id)")
       Text("DEBUG MODE title: \(viewModel.todoData.title)")
+      Text("DEBUG MODE completed: \(viewModel.todoData.completed)")
+      
+      // ✅ 네트워크 테스트 레이블
+      Text("🛜 NETWORK API TEST")
+        .font(.headline)
+        .padding(.top, 24)
+      
+      // ✅ 버튼 목록
+      ForEach(TestAction.allCases) { test in
+        Button(action: {
+          print("👉 \(test.rawValue)")
+          viewModel.handleAction(test.action)
+        }) {
+          Text(test.rawValue)
+            .frame(width: 200, height: 25)
+        }
+        .buttonStyle(.borderedProminent)
+        .padding(.bottom, 8)
+      }
+      
 #else
       Text("Release MODE")
         .foregroundColor(.blue)
@@ -29,9 +70,6 @@ public struct MainView: View {
       Text("Release MODE id: \(viewModel.todoData.id)")
       Text("Release MODE title: \(viewModel.todoData.title)")
 #endif
-    }
-    .onAppear {
-      viewModel.handleAction(action: .onAppear)
     }
   }
 }

--- a/HumanNeverDie/Projects/Features/MainFeature/Sources/MainViewModel.swift
+++ b/HumanNeverDie/Projects/Features/MainFeature/Sources/MainViewModel.swift
@@ -14,31 +14,51 @@ import MainDomain
 @MainActor
 public final class MainViewModel {
   enum Action {
-    case onAppear
+    case onGetTapped
+    case onPostTapped
+    case onPutTapped
+    case onPatchTapped
+    case onDeleteTapped
   }
   
-  private(set) var todoData: Todo = .init(userId: 0, id: 0, title: "")
+  private(set) var todoData: Todo = .init(id: 0, userId: 0, title: "")
+  private(set) var todoDataWithTest: Todo = .init(id: 3, userId: 2, title: "dataTest")
+  private(set) var todoDataWithEdit: TodoEditing = .init(id: 5, title: "Edit")
   
   private let mainUseCase: MainUseCase
   public init(mainUseCase: MainUseCase) {
     self.mainUseCase = mainUseCase
   }
   
-  func handleAction(action: Action) {
-    switch action {
-    case .onAppear:
-      Task { await fetchTodo() }
+  func handleAction(_ action: Action) {
+    Task {
+      do {
+        switch action {
+        case .onGetTapped:
+          todoData = try await mainUseCase.fetchTodo(id: todoDataWithTest.id)
+          print("GET 결과:", todoData)
+          
+        case .onPostTapped:
+          todoData = try await mainUseCase.postTodo(todo: todoDataWithTest)
+          print("POST 결과:", todoData)
+          
+        case .onPutTapped:
+          todoData = try await mainUseCase.putTodo(todo: todoDataWithTest)
+          print("PUT 결과:", todoData)
+          
+        case .onPatchTapped:
+          todoData = try await mainUseCase.patchTodo(todoEditing: todoDataWithEdit)
+          print("PATCH 결과:", todoData)
+          
+        case .onDeleteTapped:
+          let result = try await mainUseCase.deleteTodo(id: todoDataWithTest.id)
+          todoData.completed = result
+          print("DELETE 결과:", result)
+        }
+      } catch {
+        print("\(action) 실패:", error)
+      }
     }
   }
   
-  private func fetchTodo() async {
-    do {
-      let todo = try await mainUseCase.fetchTodo()
-      
-      print("네트워크 통신 결과:", todo)
-      todoData = todo
-    } catch {
-      print(error)
-    }
-  }
 }

--- a/HumanNeverDie/Projects/Features/MainFeature/Sources/MainViewModel.swift
+++ b/HumanNeverDie/Projects/Features/MainFeature/Sources/MainViewModel.swift
@@ -52,7 +52,6 @@ public final class MainViewModel {
           
         case .onDeleteTapped:
           let result = try await mainUseCase.deleteTodo(id: todoDataWithTest.id)
-          todoData.completed = result
           print("DELETE 결과:", result)
         }
       } catch {


### PR DESCRIPTION
## 🔗 관련 이슈
- Resolved: #3 

## 🛠️ 작업한 내용
- APIEndpoint에 headers 추가
- Todo 모델에 completed 기본값 추가
- TodoResponse에 completed 반영
- 삭제 응답 처리 로직 개선
- URLSession → Alamofire로 변경

## 🚨 참고 사항
- 서버 에러 코드와 디스크립션 매핑 작업 시 함께 진행 예정

## 💬 논의하고 싶은 내용
- DELETE 요청 응답이 빈 JSON({})으로 오는 경우, JSONDecoder에서 파싱 에러가 발생하여 실패로 처리되던 문제가 있었습니다.
이를 해결하기 위해 응답 코드가 200번대일 때 바디가 비었는지 확인 후 fallback JSON을 구성해 디코딩하는 방식으로 대응했습니다.
- 현재는 DELETE 요청만 별도로 처리하고 있는데, 이런 방식이 괜찮은지, 혹은 더 좋은 구조가 있을지 리뷰 시 의견 부탁드립니다. 🙏