### PR TITLE
[Feature] 날짜 선택 BottomSheet 뷰 구현

### DIFF
--- a/HumanNeverDie/Projects/CommonFeature/DesignSystem/Sources/Components/AMDDatePicker/AMDDatePickerViewController.swift
+++ b/HumanNeverDie/Projects/CommonFeature/DesignSystem/Sources/Components/AMDDatePicker/AMDDatePickerViewController.swift
@@ -52,8 +52,6 @@ public final class AMDDatePickerViewController: UIViewController {
   
   public override func viewWillLayoutSubviews() {
     super.viewWillLayoutSubviews()
-    
-    picker.subviews[1].backgroundColor = .clear
   }
   
   private func setupPickerView() {
@@ -294,8 +292,6 @@ extension AMDDatePickerViewController: UIPickerViewDataSource, UIPickerViewDeleg
     }
     
     let isSelected = pickerView.selectedRow(inComponent: component) == row
-    
-    label.backgroundColor = isSelected ? .gray15 : UIColor.clear
     label.textColor = isSelected ? .gray85 : .gray60
     
     return containerView

--- a/HumanNeverDie/Projects/CommonFeature/DesignSystem/Sources/Views/AMDatePickerView.swift
+++ b/HumanNeverDie/Projects/CommonFeature/DesignSystem/Sources/Views/AMDatePickerView.swift
@@ -1,0 +1,61 @@
+//
+//  AMDatePickerView.swift
+//  DesignSystem
+//
+//  Created by 김규철 on 7/5/25.
+//
+
+import SwiftUI
+
+public struct AMDDatePickerView: View {
+  private let title: String
+  private let type: AMDDatePicker.PickerType
+  private let action: (Date) -> Void
+  
+  @State private var date: Date = Date()
+  
+  public init(
+    title: String,
+    type: AMDDatePicker.PickerType,
+    action: @escaping (Date) -> Void
+  ) {
+    self.title = title
+    self.type = type
+    self.action = action
+  }
+  
+  public var body: some View {
+    VStack(spacing: 10) {
+      titleView
+      datePickerView
+      buttonView
+    }
+    .padding(.vertical, 10)
+    .padding(.horizontal, 20)
+    .ignoresSafeArea(edges: .bottom)
+  }
+  
+  private var titleView: some View {
+    Text(title)
+      .amdFont(.largeBold)
+      .foregroundStyle(.gray85)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .multilineTextAlignment(.leading)
+  }
+  
+  private var datePickerView: some View {
+    AMDDatePicker(
+      selectedDate: $date,
+      pickerType: type
+    )
+    .frame(maxWidth: .infinity, minHeight: 184, maxHeight: 184)
+  }
+  
+  private var buttonView: some View {
+    AMDButton(
+      type: .default,
+      title: "확인",
+      action: { action(date) }
+    )
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Resolved: #41 

## 🛠️ 작업한 내용
<!-- 작업한 내용을 적어주세요. -->

- 날짜 선택 바텀시트 뷰

```
    .amdBottomSheet(isPresented: .constant(true), detents: [.height(310)]) {
      AMDDatePickerView(title: "생년월일", type: .yearMonthDay) {
        print($0)
      }
    }
```

## 📸 스크린샷(선택)

<img src="https://github.com/user-attachments/assets/cc157429-79f7-4d72-823b-fc7bb8fecef7" width="350">


