### PR TITLE
fix: SplashView의 잘못 변경된 화면 전환 대상(onboarding → main) 복구

### DIFF
--- a/HumanNeverDie/Projects/Features/SplashFeature/Sources/SplashView.swift
+++ b/HumanNeverDie/Projects/Features/SplashFeature/Sources/SplashView.swift
@@ -27,7 +27,7 @@ public struct SplashView: View {
     .onAppear {
       DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
         withAnimation {
-          router.setRoute(.onboarding)
+          router.setRoute(.main)
         }
       }
     }


### PR DESCRIPTION
## 🔗 관련 이슈
- Resolved: #50 

## 🛠️ 작업한 내용
SplashView의 잘못 변경된 화면 전환 대상(onboarding → main) 복구

## 📸 스크린샷(선택)

## 🚨 참고 사항


