### PR TITLE
[Bug] 화면 플로우 확인 및 버그 & 수정사항 반영

### DIFF
--- a/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/GlobalState/GlobalState.swift
+++ b/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/GlobalState/GlobalState.swift
@@ -40,3 +40,14 @@ public extension DependencyValues {
     set { self[GlobalStateKey.self] = newValue }
   }
 }
+
+public func isTodayOrPastSelectedDate(_ selectedDate: Date?) -> Bool {
+  guard let selectedDate else {
+    return false
+  }
+  
+  let today = Calendar.current.startOfDay(for: Date())
+  let target = Calendar.current.startOfDay(for: selectedDate)
+  
+  return target <= today
+}

--- a/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/Calendar/Factory/AMDCalendarFactory.swift
+++ b/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/Calendar/Factory/AMDCalendarFactory.swift
@@ -12,7 +12,7 @@ public struct AMDCalendarFactory {
   public static func createMonth(
     currentDate: Date,
     sugarIntakeRecordData: [SugarIntakeRecord],
-    userSugarTargetValue: Int,
+    userSugarTargetValue: Binding<Int>,
     selectedDate: Binding<Date?>,
     onTapTitle: @escaping () -> Void,
     onMonthChanged: @escaping (Date) -> Void
@@ -30,7 +30,7 @@ public struct AMDCalendarFactory {
   public static func createWeekly(
     currentDate: Date,
     sugarIntakeRecordData: [SugarIntakeRecord],
-    userSugarTargetValue: Int,
+    userSugarTargetValue: Binding<Int>,
     selectedDate: Binding<Date?>,
     onTapTitle: @escaping () -> Void,
     onWeekChanged: @escaping (Date) -> Void

--- a/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/Calendar/UseSample/AMDCalendarSampleView.swift
+++ b/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/Calendar/UseSample/AMDCalendarSampleView.swift
@@ -28,7 +28,7 @@ public struct AMDCalendarSampleView: View {
         AMDCalendarFactory.createMonth(
           currentDate: viewModel.currentDate,
           sugarIntakeRecordData: viewModel.sugarIntakeRecordData,
-          userSugarTargetValue: 50,
+          userSugarTargetValue: $viewModel.sugerValue,
           selectedDate: $viewModel.selectedDate,
           onTapTitle: {
             tempDate = viewModel.selectedDate ?? Date()
@@ -56,7 +56,7 @@ public struct AMDCalendarSampleView: View {
         AMDCalendarFactory.createWeekly(
           currentDate: viewModel.currentDate,
           sugarIntakeRecordData: viewModel.sugarIntakeRecordData,
-          userSugarTargetValue: 50,
+          userSugarTargetValue: $viewModel.sugerValue,
           selectedDate: $viewModel.selectedDate,
           onTapTitle: {
             tempDate = viewModel.selectedDate ?? Date()

--- a/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/Calendar/UseSample/AMDCalendarSampleViewModel.swift
+++ b/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/Calendar/UseSample/AMDCalendarSampleViewModel.swift
@@ -12,6 +12,7 @@ import Observation
 public final class AMDCalendarSampleViewModel {
   private(set) var currentDate: Date = Date()
   private(set) var sugarIntakeRecordData: [SugarIntakeRecord] = AMDCalendarSampleViewModel.sampleData
+  var sugerValue: Int = 50
   var selectedDate: Date? = nil
   
   public struct State: Equatable {

--- a/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/Calendar/View/AMDCalendarCommonViews.swift
+++ b/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/Calendar/View/AMDCalendarCommonViews.swift
@@ -24,7 +24,7 @@ public struct CalendarTitleView: View {
       Spacer()
     }
     .frame(maxWidth: .infinity)
-    .padding(.vertical, 14)
+    .padding(.bottom, 14)
   }
 }
 

--- a/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/Calendar/View/AMDMonthCalendarView.swift
+++ b/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/Calendar/View/AMDMonthCalendarView.swift
@@ -10,16 +10,16 @@ import SwiftUI
 struct AMDMonthCalendarView: View {
   @State private var viewModel: AMDMonthCalendarViewModel
   @Binding var selectedDate: Date?
+  @Binding var userSugarTargetValue: Int
   private let onTapTitle: () -> Void
   private let onMonthChanged: (Date) -> Void
   private let currentDate: Date
   private let sugarIntakeRecordData: [SugarIntakeRecord]
-  private let userSugarTargetValue: Int
   
   init(
     currentDate: Date,
     sugarIntakeRecordData: [SugarIntakeRecord],
-    userSugarTargetValue: Int,
+    userSugarTargetValue: Binding<Int>,
     selectedDate: Binding<Date?>,
     onTapTitle: @escaping () -> Void,
     onMonthChanged: @escaping (Date) -> Void
@@ -27,16 +27,16 @@ struct AMDMonthCalendarView: View {
     // 외부 데이터 저장
     self.currentDate = currentDate
     self.sugarIntakeRecordData = sugarIntakeRecordData
-    self.userSugarTargetValue = userSugarTargetValue
+    self._userSugarTargetValue = userSugarTargetValue
     self._selectedDate = selectedDate
     self.onTapTitle = onTapTitle
     self.onMonthChanged = onMonthChanged
     
-    // viewModel 초기 생성
+    // viewModel 초기 생성 (Binding을 넘겨줌)
     self._viewModel = State(initialValue: AMDMonthCalendarViewModel(
       currentDate: currentDate,
       sugarIntakeRecordData: sugarIntakeRecordData,
-      userSugarTargetValue: userSugarTargetValue
+      userSugarTargetValue: userSugarTargetValue  // 🎯 Binding 전달
     ))
   }
   
@@ -55,6 +55,10 @@ struct AMDMonthCalendarView: View {
     }
     .onChange(of: sugarIntakeRecordData) { _, newData in
       viewModel.updateSugarIntakeData(newData)
+    }
+    // 🎯 userSugarTargetValue 변경 감지 추가
+    .onChange(of: userSugarTargetValue) { _, _ in
+      viewModel.updateDayModels() // 캘린더 다시 그리기
     }
     .highPriorityGesture(
       

--- a/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/Calendar/View/AMDWeekCalendarView.swift
+++ b/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/Calendar/View/AMDWeekCalendarView.swift
@@ -10,16 +10,16 @@ import SwiftUI
 struct AMDWeekCalendarView: View {
   @State private var viewModel: AMDWeekCalendarViewModel
   @Binding var selectedDate: Date?
+  @Binding var userSugarTargetValue: Int
   private let onTapTitle: () -> Void
   private let onWeekChanged: (Date) -> Void
   private let currentDate: Date
   private let sugarIntakeRecordData: [SugarIntakeRecord]
-  private let userSugarTargetValue: Int
   
   init(
     currentDate: Date,
     sugarIntakeRecordData: [SugarIntakeRecord],
-    userSugarTargetValue: Int,
+    userSugarTargetValue: Binding<Int>,
     selectedDate: Binding<Date?>,
     onTapTitle: @escaping () -> Void,
     onWeekChanged: @escaping (Date) -> Void
@@ -27,7 +27,7 @@ struct AMDWeekCalendarView: View {
     // 외부 데이터 저장
     self.currentDate = currentDate
     self.sugarIntakeRecordData = sugarIntakeRecordData
-    self.userSugarTargetValue = userSugarTargetValue
+    self._userSugarTargetValue = userSugarTargetValue
     self._selectedDate = selectedDate
     self.onTapTitle = onTapTitle
     self.onWeekChanged = onWeekChanged

--- a/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/Calendar/ViewModel/AMDCommonCalendarViewModel.swift
+++ b/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/Calendar/ViewModel/AMDCommonCalendarViewModel.swift
@@ -39,9 +39,8 @@ class AMDCommonCalendarViewModel {
   }
   
   func getStateIcon(for value: Int) -> Image? {
-    let targetValue = userSugarTargetValue.wrappedValue  // 🎯 .wrappedValue로 실제 값 접근
+    let targetValue = userSugarTargetValue.wrappedValue
     let sugerValue = Double(value) / Double(targetValue) * 100
-    print("🍯 \(value) ÷ \(targetValue) × 100 = \(sugerValue)%")
     return AMDStateIcon(percentage: sugerValue).icon
   }
   

--- a/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/Calendar/ViewModel/AMDCommonCalendarViewModel.swift
+++ b/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/Calendar/ViewModel/AMDCommonCalendarViewModel.swift
@@ -7,10 +7,11 @@
 
 import SwiftUI
 
+@Observable
 class AMDCommonCalendarViewModel {
   private var selectedDate: Date? = nil
   private(set) var currentDate: Date
-  private let userSugarTargetValue: Int
+  @ObservationIgnored private let userSugarTargetValue: Binding<Int> 
   var sugarIntakeRecordData: [SugarIntakeRecord]
   let calendar = Calendar.current
   let dragThreshold: CGFloat = 50
@@ -19,7 +20,11 @@ class AMDCommonCalendarViewModel {
     Array(repeating: GridItem(.flexible()), count: weekdayItems.count)
   }
   
-  init(currentDate: Date, sugarIntakeRecordData: [SugarIntakeRecord], userSugarTargetValue: Int) {
+  init(
+    currentDate: Date,
+    sugarIntakeRecordData: [SugarIntakeRecord],
+    userSugarTargetValue: Binding<Int>
+  ) {
     self.currentDate = currentDate
     self.sugarIntakeRecordData = sugarIntakeRecordData
     self.userSugarTargetValue = userSugarTargetValue
@@ -34,7 +39,9 @@ class AMDCommonCalendarViewModel {
   }
   
   func getStateIcon(for value: Int) -> Image? {
-    let sugerValue = Double(value) / Double(userSugarTargetValue) * 100
+    let targetValue = userSugarTargetValue.wrappedValue  // 🎯 .wrappedValue로 실제 값 접근
+    let sugerValue = Double(value) / Double(targetValue) * 100
+    print("🍯 \(value) ÷ \(targetValue) × 100 = \(sugerValue)%")
     return AMDStateIcon(percentage: sugerValue).icon
   }
   

--- a/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/Calendar/ViewModel/AMDMonthCalendarViewModel.swift
+++ b/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/Calendar/ViewModel/AMDMonthCalendarViewModel.swift
@@ -15,7 +15,7 @@ class AMDMonthCalendarViewModel: AMDCommonCalendarViewModel {
   override init(
     currentDate: Date,
     sugarIntakeRecordData: [SugarIntakeRecord],
-    userSugarTargetValue: Int
+    userSugarTargetValue: Binding<Int>
   ) {
     super.init(
       currentDate: currentDate,

--- a/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/Calendar/ViewModel/AMDWeekCalendarViewModel.swift
+++ b/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/Calendar/ViewModel/AMDWeekCalendarViewModel.swift
@@ -15,7 +15,7 @@ class AMDWeekCalendarViewModel: AMDCommonCalendarViewModel {
   override init(
     currentDate: Date,
     sugarIntakeRecordData: [SugarIntakeRecord],
-    userSugarTargetValue: Int
+    userSugarTargetValue: Binding<Int>
   ) {
     super.init(
       currentDate: currentDate,

--- a/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/Calendar/ViewModel/AMDWeekCalendarViewModel.swift
+++ b/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/Calendar/ViewModel/AMDWeekCalendarViewModel.swift
@@ -65,17 +65,20 @@ class AMDWeekCalendarViewModel: AMDCommonCalendarViewModel {
   }
   
   func updateDayModels() {
-    let extracted = extractDate()
-    dayModels = extracted.map { value in
-      CalendarDayModel(
-        value: value,
-        isToday: isToday(value.date),
-        isSelected: isSelected(value.date),
-        textColor: textColor(for: value.date),
-        stateIcon: matchingValue(for: value.date).flatMap { getStateIcon(for: $0)}
-      )
-    }
+      let extracted = extractDate()
+      dayModels = extracted.map { value in
+        let dateWithCurrentTime = value.date.applyingCurrentTime()
+       
+        return CalendarDayModel(
+          value: DateValue(day: value.day, date: dateWithCurrentTime),
+          isToday: isToday(dateWithCurrentTime),
+          isSelected: isSelected(dateWithCurrentTime),
+          textColor: textColor(for: dateWithCurrentTime),
+          stateIcon: matchingValue(for: dateWithCurrentTime).flatMap { getStateIcon(for: $0) }
+        )
+      }
   }
+
   
   func updateSugarIntakeData(_ newData: [SugarIntakeRecord]) {
     self.sugarIntakeRecordData = newData
@@ -92,4 +95,19 @@ extension Date {
     let components = calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: self)
     return calendar.date(from: components)!
   }
+  
+  func applyingCurrentTime() -> Date {
+    let calendar = Calendar.current
+    let now = Date()
+    
+    var dateComponents = calendar.dateComponents([.year, .month, .day], from: self)
+    let timeComponents = calendar.dateComponents([.hour, .minute, .second], from: now)
+    
+    dateComponents.hour = timeComponents.hour
+    dateComponents.minute = timeComponents.minute
+    dateComponents.second = timeComponents.second
+    
+    return calendar.date(from: dateComponents)!
+  }
 }
+

--- a/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/SugarCalculationInfoContent/SugarCalculationInfoContent.swift
+++ b/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/SugarCalculationInfoContent/SugarCalculationInfoContent.swift
@@ -1,0 +1,224 @@
+//
+//  sugarCalculationInfoContent.swift
+//  CommonFeature
+//
+//  Created by Seulki Lee on 8/23/25.
+//
+
+import SwiftUI
+import DesignSystem
+
+public struct SugarCalculationInfoContent: View {
+  let onDismiss: () -> Void
+  
+  public init(onDismiss: @escaping () -> Void) {
+    self.onDismiss = onDismiss
+  }
+  
+  public var body: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 24) {
+        Text("아맞당은 당 섭취량을 이렇게 계산해요")
+          .amdFont(.largeBold)
+          .foregroundColor(.gray85)
+        
+        // 1번 섹션
+        HStack(alignment: .top, spacing: 8) {
+          Text("1.")
+            .amdFont(.mediumRegular)
+            .foregroundColor(.gray80)
+            .frame(width: 20, alignment: .leading)
+          
+          VStack(alignment: .leading, spacing: 12) {
+            Text("성별, 나이, 키 정보로 기초 대사량을 먼저 계산한 후 활동량을 고래 활동 대사량을 계산해요.")
+              .amdFont(.mediumRegular)
+              .foregroundColor(.gray80)
+            
+            VStack(alignment: .leading, spacing: 8) {
+              HStack {
+                Text("기초대사량 계산법")
+                  .amdFont(.smallRegular)
+                  .foregroundColor(.gray70)
+                Image(systemName: "chevron.down")
+                  .font(.system(size: 12))
+                  .foregroundColor(.gray70)
+                Spacer()
+              }
+              
+              VStack(alignment: .leading, spacing: 8) {
+                Text("• 18-30세")
+                  .amdFont(.smallRegular)
+                  .foregroundColor(.gray70)
+                
+                VStack(alignment: .leading, spacing: 4) {
+                  Text("  • 남성: 15.3 × 체중 + 679")
+                    .amdFont(.smallRegular)
+                    .foregroundColor(.gray70)
+                  Text("  • 여성: 14.7 × 체중 + 496")
+                    .amdFont(.smallRegular)
+                    .foregroundColor(.gray70)
+                }
+                
+                Text("• 30-60세")
+                  .amdFont(.smallRegular)
+                  .foregroundColor(.gray70)
+                
+                VStack(alignment: .leading, spacing: 4) {
+                  Text("  • 남성: 11.6 × 체중 + 879")
+                    .amdFont(.smallRegular)
+                    .foregroundColor(.gray70)
+                  Text("  • 여성: 8.7 × 체중 + 829")
+                    .amdFont(.smallRegular)
+                    .foregroundColor(.gray70)
+                }
+                
+                Text("• 60세 이상")
+                  .amdFont(.smallRegular)
+                  .foregroundColor(.gray70)
+                
+                VStack(alignment: .leading, spacing: 4) {
+                  Text("  • 남성: 13.5 × 체중 + 487")
+                    .amdFont(.smallRegular)
+                    .foregroundColor(.gray70)
+                  Text("  • 여성: 10.5 × 체중 + 596")
+                    .amdFont(.smallRegular)
+                    .foregroundColor(.gray70)
+                }
+              }
+              .padding(.leading, 8)
+            }
+          }
+        }
+        
+        HStack(alignment: .top, spacing: 8) {
+          Text("2.")
+            .amdFont(.mediumRegular)
+            .foregroundColor(.gray80)
+            .frame(width: 20, alignment: .leading)
+          
+          VStack(alignment: .leading, spacing: 12) {
+            Text("활동량에 따라 신체 활동 수준 값을 적용해서 총 에너지 요구량을 계산해요.")
+              .amdFont(.mediumRegular)
+              .foregroundColor(.gray80)
+            
+            VStack(alignment: .leading, spacing: 8) {
+              HStack {
+                Text("신체 활동 수준 값")
+                  .amdFont(.smallRegular)
+                  .foregroundColor(.gray70)
+                Image(systemName: "chevron.down")
+                  .font(.system(size: 12))
+                  .foregroundColor(.gray70)
+                Spacer()
+              }
+              
+              VStack(alignment: .leading, spacing: 8) {
+                Text("• 가벼운 활동: 1.4-1.5")
+                  .amdFont(.smallRegular)
+                  .foregroundColor(.gray70)
+                Text("• 보통 활동: 1.6-1.7")
+                  .amdFont(.smallRegular)
+                  .foregroundColor(.gray70)
+                Text("• 활발한 활동: 1.8-1.9")
+                  .amdFont(.smallRegular)
+                  .foregroundColor(.gray70)
+              }
+              .padding(.leading, 8)
+            }
+          }
+        }
+        
+        VStack(alignment: .leading, spacing: 12) {
+          HStack(alignment: .top, spacing: 8) {
+            Text("3.")
+              .amdFont(.mediumRegular)
+              .foregroundColor(.gray80)
+              .frame(width: 20, alignment: .leading)
+            
+            VStack(alignment: .leading, spacing: 12) {
+              Text("계산된 총 에너지 요구량을 바탕으로 WHO 세계 표준 권장 당류 계산식을 적용해 일일 권장 당 섭취량을 도출해요.")
+                .amdFont(.mediumRegular)
+                .foregroundColor(.gray80)
+              
+              VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                  Text("당류 목표량 계산")
+                    .amdFont(.smallRegular)
+                    .foregroundColor(.gray70)
+                  Image(systemName: "chevron.down")
+                    .font(.system(size: 12))
+                    .foregroundColor(.gray70)
+                  Spacer()
+                }
+                
+                VStack(alignment: .leading, spacing: 12) {
+                  VStack(alignment: .leading, spacing: 8) {
+                    Text("1단계 - 당류 칼로리(kcal) 계산")
+                      .amdFont(.smallRegular)
+                      .foregroundColor(.gray70)
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                      Text("• 일일 권장량: 총 에너지 요구량 × 10%")
+                        .amdFont(.smallRegular)
+                        .foregroundColor(.gray70)
+                      Text("• 이상적 목표량: 총 에너지 요구량 × 5% (WHO 강력 권장)")
+                        .amdFont(.smallRegular)
+                        .foregroundColor(.gray70)
+                    }
+                    .padding(.leading, 8)
+                  }
+                  
+                  VStack(alignment: .leading, spacing: 8) {
+                    Text("2단계 - 그램(gram) 변환")
+                      .amdFont(.smallRegular)
+                      .foregroundColor(.gray70)
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                      Text("• 당류 1g = 4kcal")
+                        .amdFont(.smallRegular)
+                        .foregroundColor(.gray70)
+                      Text("• 당류량(g) = 당류 칼로리 ÷ 4")
+                        .amdFont(.smallRegular)
+                        .foregroundColor(.gray70)
+                    }
+                  }
+                }
+              }
+            }
+          }
+          
+          // 주의사항
+          VStack(alignment: .leading, spacing: 4) {
+            Text("*정확한 권장 당류 섭취량은 개인 체질에 따라 다를 수 있으니 참고해주세요.")
+              .amdFont(.xsmallRegular)
+              .foregroundColor(.gray60)
+            
+            Text("*BMI에 따라 신체 활동 수준 값이 달라질 수 있어요.")
+              .amdFont(.xsmallRegular)
+              .foregroundColor(.gray60)
+            
+            Text("*신체 질환이나 질병이 있다면 의료진과 상담해주세요.")
+              .amdFont(.xsmallRegular)
+              .foregroundColor(.gray60)
+          }
+          .padding(.top, 8)
+        }
+        
+        AMDButton(
+          type: .secondary,
+          title: "닫기",
+          action: onDismiss
+        )
+        
+      }
+      .padding(.horizontal, 20)
+      .padding(.top, 20)
+    }
+  }
+}
+
+#Preview {
+  SugarCalculationInfoContent {
+    print("닫기 버튼 눌림")
+  }
+}

--- a/HumanNeverDie/Projects/Data/Data/Sources/Beverage/Repository/BeverageRepository.swift
+++ b/HumanNeverDie/Projects/Data/Data/Sources/Beverage/Repository/BeverageRepository.swift
@@ -115,6 +115,17 @@ public final class BeverageRepository: BeverageRepositoryInterface, @unchecked S
     return response.map { $0.toDomain() }
   }
   
+  public func getBeveragDailyCalender(dailyDate: String) async throws -> BeverageCalendar {
+    let target = BeverageDailyCalenderTarget(dailyDate: dailyDate)
+    let result = try await networkService.requestDDD(target)
+    
+    guard let response = result.data else {
+      throw AMDNetworkError.emptyResponse
+    }
+    
+    return response.toDomain()
+  }
+  
   public func deleteBeverage(productID: String, intakeTime: String) async throws -> Int {
     let target = BeverageDelete(productID: productID, intakeTime: intakeTime)
     let result = try await networkService.requestDDD(target)

--- a/HumanNeverDie/Projects/Data/Data/Sources/Beverage/Repository/UserRepository.swift
+++ b/HumanNeverDie/Projects/Data/Data/Sources/Beverage/Repository/UserRepository.swift
@@ -60,5 +60,15 @@ public final class UserRepository: UserRepositoryInterface, @unchecked Sendable 
 
     return response.toDomain()
   }
-}
+  
+  public   func updateNotifications(userID: String, isEnabled: Bool) async throws -> UserNotifications {
+    let target = NotificationUpdateTarget(userID: userID, isEnabled: isEnabled)
+    let result = try await networkService.requestDDD(target)
 
+    guard let response = result.data else {
+      throw AMDNetworkError.emptyResponse
+    }
+
+    return response.toDomain()
+  }
+}

--- a/HumanNeverDie/Projects/Data/Data/Sources/Beverage/Request/UserRecordRequest.swift
+++ b/HumanNeverDie/Projects/Data/Data/Sources/Beverage/Request/UserRecordRequest.swift
@@ -17,6 +17,10 @@ struct UserRecordRequest: Encodable {
   let sugarIntakeLevel: String
 }
 
+struct NotificationsRequest: Encodable {
+  let isEnabled: Bool
+}
+
 
 struct UserNotificationsRequest: Encodable {
  let isEnabled: Bool

--- a/HumanNeverDie/Projects/Data/Data/Sources/Beverage/Target/BeverageDailyCalenderTarget.swift
+++ b/HumanNeverDie/Projects/Data/Data/Sources/Beverage/Target/BeverageDailyCalenderTarget.swift
@@ -1,0 +1,44 @@
+//
+//  BeverageDailyCalenderTarget.swift
+//  Data
+//
+//  Created by Seulki Lee on 8/22/25.
+//
+
+import Foundation
+
+import BaseNetwork
+import BeverageDomain
+
+struct BeverageDailyCalenderTarget: AMDAPIRequestable {
+  typealias Response = AMDAPIResponse<BeverageCalendarResponse>
+  
+  private let dailyDate: String?
+  
+  init(
+    dailyDate: String? = nil
+  ) {
+    self.dailyDate = dailyDate
+  }
+  
+  var path: String {
+    return "/intake-histories/daily"
+  }
+  
+  var method: AMDHTTPMethod {
+    return .GET
+  }
+  
+  var headers: [String : String]? {
+    nil
+  }
+  
+  var queryParameters: [String : String]? {
+    guard let dailyDate else { return [:] }
+    return ["intakeTime": dailyDate]
+  }
+  
+  var body: Encodable? {
+    return nil
+  }
+}

--- a/HumanNeverDie/Projects/Data/Data/Sources/Beverage/Target/BeverageRecordTarget.swift
+++ b/HumanNeverDie/Projects/Data/Data/Sources/Beverage/Target/BeverageRecordTarget.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Shared
 
 import BaseNetwork
 
@@ -37,7 +38,8 @@ struct BeverageRecordTarget: AMDAPIRequestable {
   }
   
   var body: Encodable? {
-    let request = BeverageRecordRequest(productId: productID, intakeTime: recordDate.ISO8601Format())
+    let dateKtc = Date.toRequestDateKeyString(from: recordDate)
+    let request = BeverageRecordRequest(productId: productID, intakeTime: dateKtc)
     
     return request
   }

--- a/HumanNeverDie/Projects/Data/Data/Sources/Beverage/Target/UserUseNotificationsUpdateTarget.swift
+++ b/HumanNeverDie/Projects/Data/Data/Sources/Beverage/Target/UserUseNotificationsUpdateTarget.swift
@@ -1,0 +1,48 @@
+//
+//  UserUseNotificationsUpdateTarget.swift
+//  Data
+//
+//  Created by Seulki Lee on 8/22/25.
+//
+
+import Foundation
+
+import BaseNetwork
+import UserDomain
+
+struct NotificationUpdateTarget: AMDAPIRequestable {
+  typealias Response = AMDAPIResponse<UserNotificationsResponse>
+  
+  private let userID: String
+  private let isEnabled: Bool
+  
+  init(userID: String, isEnabled: Bool) {
+    self.userID = userID
+    self.isEnabled = isEnabled
+  }
+  
+  var path: String {
+    return "/members/\(userID)/notification-settings"
+  }
+  
+  var method: AMDHTTPMethod {
+    return .PATCH
+  }
+  
+  var headers: [String : String]? {
+    return nil
+  }
+  
+  var queryParameters: [String: String]? {
+    return nil
+  }
+  
+  var body: Encodable? {
+    let request = NotificationsRequest(
+      isEnabled: isEnabled)
+    
+    return request
+  }
+}
+
+

--- a/HumanNeverDie/Projects/Domain/BeverageDomain/Sources/Entity/BeverageCalendar.swift
+++ b/HumanNeverDie/Projects/Domain/BeverageDomain/Sources/Entity/BeverageCalendar.swift
@@ -37,6 +37,7 @@ public struct BeverageCalendar: Equatable, Sendable {
 
 public extension BeverageCalendar {
   static func mock() -> [BeverageCalendar] { mockData }
+  static func dailyMock() -> BeverageCalendar { mockData[0] }
   
   private static var mockData: [BeverageCalendar] {
     return [

--- a/HumanNeverDie/Projects/Domain/BeverageDomain/Sources/RepositoryInterface/BeverageRepositoryInterface+Dependency.swift
+++ b/HumanNeverDie/Projects/Domain/BeverageDomain/Sources/RepositoryInterface/BeverageRepositoryInterface+Dependency.swift
@@ -32,6 +32,7 @@ private struct MockBeverageRepository: BeverageRepositoryInterface {
   func getBeverageDetail(productID: String) async throws -> BeverageDetail { BeverageDetail.mock() }
   func getBeverageMonthCalender(dateInWeek: String) async throws -> [BeverageCalendar] { BeverageCalendar.mock() }
   func getBeverageWeeklyCalender(dateInWeek: String) async throws -> [BeverageCalendar] { BeverageCalendar.mock() }
+  func getBeveragDailyCalender(dailyDate: String) async throws -> BeverageCalendar { BeverageCalendar.dailyMock() }
   func likeBeverage(productID: String) async throws -> BeverageLike { BeverageLike.mock() }
   func unLikeBeverage(productID: String) async throws -> BeverageLike { BeverageLike.mock() }
   func searchBeverage(keyword: String, sugarLevel: String?, onlyLiked: Bool) async throws -> BeverageList { BeverageList.mock() }

--- a/HumanNeverDie/Projects/Domain/BeverageDomain/Sources/RepositoryInterface/BeverageRepositoryInterface.swift
+++ b/HumanNeverDie/Projects/Domain/BeverageDomain/Sources/RepositoryInterface/BeverageRepositoryInterface.swift
@@ -13,6 +13,7 @@ public protocol BeverageRepositoryInterface: Sendable {
   func getBeverageDetail(productID: String) async throws -> BeverageDetail
   func getBeverageMonthCalender(dateInWeek: String) async throws -> [BeverageCalendar]
   func getBeverageWeeklyCalender(dateInWeek: String) async throws -> [BeverageCalendar]
+  func getBeveragDailyCalender(dailyDate: String) async throws -> BeverageCalendar
   func likeBeverage(productID: String) async throws -> BeverageLike
   func unLikeBeverage(productID: String) async throws -> BeverageLike
   func searchBeverage(keyword: String, sugarLevel: String?, onlyLiked: Bool) async throws -> BeverageList

--- a/HumanNeverDie/Projects/Domain/BeverageDomain/Sources/UseCases/BeverageUseCase+Dependency.swift
+++ b/HumanNeverDie/Projects/Domain/BeverageDomain/Sources/UseCases/BeverageUseCase+Dependency.swift
@@ -32,6 +32,7 @@ private struct MockBeverageUseCase: BeverageUseCaseProtocol {
   func getBeverageDetail(productID: String) async throws -> BeverageDetail { BeverageDetail.mock() }
   func getBeverageMonthCalender(dateInWeek: String) async throws -> [BeverageCalendar] { BeverageCalendar.mock() }
   func getBeverageWeeklyCalender(dateInWeek: String) async throws -> [BeverageCalendar] { BeverageCalendar.mock() }
+  func getBeveragDailyCalender(dailyDate: String) async throws -> BeverageCalendar { BeverageCalendar.dailyMock() }
   func likeBeverage(productID: String) async throws -> BeverageLike { BeverageLike.mock() }
   func unLikeBeverage(productID: String) async throws -> BeverageLike { BeverageLike.mock() }
   func searchBeverage(keyword: String, sugarLevel: BeverageSugarLevelType?, onlyLiked: Bool) async throws -> BeverageList { BeverageList.mock() }

--- a/HumanNeverDie/Projects/Domain/BeverageDomain/Sources/UseCases/BeverageUseCase.swift
+++ b/HumanNeverDie/Projects/Domain/BeverageDomain/Sources/UseCases/BeverageUseCase.swift
@@ -8,6 +8,7 @@ public protocol BeverageUseCaseProtocol: Sendable {
   func getBeverageDetail(productID: String) async throws -> BeverageDetail
   func getBeverageMonthCalender(dateInWeek: String) async throws -> [BeverageCalendar]
   func getBeverageWeeklyCalender(dateInWeek: String) async throws -> [BeverageCalendar]
+  func getBeveragDailyCalender(dailyDate: String) async throws -> BeverageCalendar
   func likeBeverage(productID: String) async throws -> BeverageLike
   func unLikeBeverage(productID: String) async throws -> BeverageLike
   func searchBeverage(keyword: String, sugarLevel: BeverageSugarLevelType?, onlyLiked: Bool) async throws -> BeverageList
@@ -116,6 +117,10 @@ public final class BeverageUseCase: BeverageUseCaseProtocol, @unchecked Sendable
   
   public func getBeverageWeeklyCalender(dateInWeek: String) async throws -> [BeverageCalendar] {
       return try await beverageRepository.getBeverageWeeklyCalender(dateInWeek: dateInWeek)
+  }
+  
+  public func getBeveragDailyCalender(dailyDate: String) async throws -> BeverageCalendar {
+    return try await beverageRepository.getBeveragDailyCalender(dailyDate: dailyDate)
   }
 
   public func deleteBeverage(productID: String, intakeTime: String) async throws -> Bool {

--- a/HumanNeverDie/Projects/Domain/UserDomain/Sources/Entity/UserNotifications.swift
+++ b/HumanNeverDie/Projects/Domain/UserDomain/Sources/Entity/UserNotifications.swift
@@ -41,7 +41,7 @@ extension UserNotifications {
   public static func defaultUserNotifications(
     isEnabled: Bool = false,
     remindersEnabled: Bool? = nil,
-    reminderTime: String = "12:00:00",
+    reminderTime: String = "15:00:00",
     riskWarningsEnabled: Bool? = nil,
     newsUpdatesEnabled: Bool? = nil
   ) -> UserNotifications {

--- a/HumanNeverDie/Projects/Domain/UserDomain/Sources/RepositoryInterface/UserRepositoryInterface+Dependency.swift
+++ b/HumanNeverDie/Projects/Domain/UserDomain/Sources/RepositoryInterface/UserRepositoryInterface+Dependency.swift
@@ -30,6 +30,7 @@ private struct MockUserRepository: UserRepositoryInterface {
   func getUserInfo(userID: String) async throws -> UserInfo { UserInfo.mock() }
   func getUserNotificationInfo(userID: String) async throws -> UserNotifications { UserNotifications.mock()}
   func updateUserInfo(userID: String, userInfo: UserInfo) async throws -> UserInfo { UserInfo.mock()}
+  func updateNotifications(userID: String, isEnabled: Bool) async throws -> UserNotifications {UserNotifications.mock()}
   func updateUserNotifications(userID: String, userNotificationsInfo: UserNotifications) async throws -> UserNotifications { UserNotifications.mock()}
 }
 

--- a/HumanNeverDie/Projects/Domain/UserDomain/Sources/RepositoryInterface/UserRepositoryInterface.swift
+++ b/HumanNeverDie/Projects/Domain/UserDomain/Sources/RepositoryInterface/UserRepositoryInterface.swift
@@ -11,5 +11,6 @@ public protocol UserRepositoryInterface: Sendable {
   func getUserInfo(userID:String) async throws -> UserInfo
   func getUserNotificationInfo(userID:String) async throws -> UserNotifications
   func updateUserInfo(userID: String, userInfo: UserInfo) async throws -> UserInfo
+  func updateNotifications(userID: String, isEnabled: Bool) async throws -> UserNotifications
   func updateUserNotifications(userID: String, userNotificationsInfo: UserNotifications) async throws -> UserNotifications
 }

--- a/HumanNeverDie/Projects/Domain/UserDomain/Sources/UseCases/UserUseCase+Dependency.swift
+++ b/HumanNeverDie/Projects/Domain/UserDomain/Sources/UseCases/UserUseCase+Dependency.swift
@@ -26,6 +26,7 @@ private struct MockUserUseCase: UserUseCaseProtocol {
   func getUserInfo(userID: String) async throws -> UserInfo { UserInfo.mock()}
   func getUserNotificationInfo(userID: String) async throws -> UserNotifications { UserNotifications.mock()}
   func updateUserInfo(userID: String, userInfo: UserInfo) async throws -> UserInfo { UserInfo.mock()}
+  func updateNotifications(userID: String, isEnabled: Bool) async throws -> UserNotifications { UserNotifications.mock()}
   func updateUserNotifications(userID: String, userNotifications: UserNotifications) async throws -> UserNotifications {
     UserNotifications.mock()
   }

--- a/HumanNeverDie/Projects/Domain/UserDomain/Sources/UseCases/UserUseCase.swift
+++ b/HumanNeverDie/Projects/Domain/UserDomain/Sources/UseCases/UserUseCase.swift
@@ -13,6 +13,7 @@ public protocol UserUseCaseProtocol: Sendable {
   func getUserInfo(userID:String) async throws -> UserInfo
   func getUserNotificationInfo(userID:String) async throws -> UserNotifications
   func updateUserInfo(userID: String, userInfo: UserInfo) async throws -> UserInfo
+  func updateNotifications(userID: String, isEnabled: Bool) async throws -> UserNotifications
   func updateUserNotifications(userID: String, userNotifications: UserNotifications) async throws -> UserNotifications
 }
 
@@ -30,6 +31,10 @@ public final class UserUseCase: UserUseCaseProtocol, @unchecked Sendable {
   
   public func updateUserInfo(userID: String, userInfo: UserInfo) async throws -> UserInfo {
     return try await userRepository.updateUserInfo(userID: userID, userInfo: userInfo)
+  }
+  
+  public func updateNotifications(userID: String, isEnabled: Bool) async throws -> UserNotifications {
+    return try await userRepository.updateNotifications(userID: userID, isEnabled: isEnabled)
   }
   
   public func updateUserNotifications(userID: String, userNotifications: UserNotifications) async throws -> UserNotifications {

--- a/HumanNeverDie/Projects/Features/HistoryFeature/Sources/HistoryView.swift
+++ b/HumanNeverDie/Projects/Features/HistoryFeature/Sources/HistoryView.swift
@@ -120,6 +120,7 @@ extension HistoryView {
           .foregroundColor(Color.gray40)
       )
     }
+    .opacity(viewModel.state.isTodayOrPastSelectedDate ? 1 : 0)
     .padding(.vertical, 10)
   }
   

--- a/HumanNeverDie/Projects/Features/HistoryFeature/Sources/HistoryView.swift
+++ b/HumanNeverDie/Projects/Features/HistoryFeature/Sources/HistoryView.swift
@@ -131,7 +131,8 @@ extension HistoryView {
         
         ForEach(historyList, id: \.intakeHistoryId) { data in
           let sugarFreeVariant = AMDSugarFreeVariant.from(data.sugarLevel) ?? .none
-          let beverageIdString = String(data.productId)
+          let uniqueIdString = String(data.intakeHistoryId)
+          let productIdString = String(data.productId)
           
           AMDBeverageListView.medium(
             thumbnailURL: data.imgUrl,
@@ -142,13 +143,16 @@ extension HistoryView {
             kcal: Double(data.servingKcal),
             sugarFreeVariant: sugarFreeVariant,
             menuAction: {
-              viewModel.handleAction(.updateSelectedProductID(beverageIdString))
+              viewModel.handleAction(.updateSelectedProductID(
+                uniqueIdString,
+                productIdString
+              ))
             }
           )
           .padding(.horizontal, 20)
           .overlay(
             Group {
-              if viewModel.state.selectedProductID == beverageIdString {
+              if viewModel.state.selectedIntakeHistoryID == uniqueIdString {
                 HStack {
                   Spacer()
                   popupMenuDailylList()

--- a/HumanNeverDie/Projects/Features/HistoryFeature/Sources/HistoryView.swift
+++ b/HumanNeverDie/Projects/Features/HistoryFeature/Sources/HistoryView.swift
@@ -77,7 +77,7 @@ extension HistoryView {
     AMDCalendarFactory.createMonth(
       currentDate: viewModel.currentDate,
       sugarIntakeRecordData: viewModel.sugarIntakeRecordData,
-      userSugarTargetValue: 50,
+      userSugarTargetValue: $viewModel.state.baseSugar,
       selectedDate: $viewModel.state.selectedDate,
       onTapTitle: {
         viewModel.handleAction(.updateisMonthPickerPresented(true))

--- a/HumanNeverDie/Projects/Features/HistoryFeature/Sources/HistoryView.swift
+++ b/HumanNeverDie/Projects/Features/HistoryFeature/Sources/HistoryView.swift
@@ -41,6 +41,7 @@ public struct HistoryView: View {
           }
         }
       }
+      .padding(.top, 4)
       .amdBottomSheet(isPresented: $viewModel.state.isBevarageDetailPresented, detents: [.height(474)]) {
         AMDBeverageDetailView(productID: viewModel.selectedProductID)
       }

--- a/HumanNeverDie/Projects/Features/HistoryFeature/Sources/HistoryView.swift
+++ b/HumanNeverDie/Projects/Features/HistoryFeature/Sources/HistoryView.swift
@@ -125,8 +125,8 @@ extension HistoryView {
   
   private var selectedHistoryDailylList: some View {
     VStack(alignment: .leading, spacing: 0) {
-      LazyVStack(spacing: 20) {
-        // 변수로 한 번 받아서 사용
+      LazyVStack(spacing: 10) {
+        
         let historyList = viewModel.selectedDateHistoryList
         
         ForEach(historyList, id: \.intakeHistoryId) { data in

--- a/HumanNeverDie/Projects/Features/HistoryFeature/Sources/HistoryViewModel.swift
+++ b/HumanNeverDie/Projects/Features/HistoryFeature/Sources/HistoryViewModel.swift
@@ -28,6 +28,7 @@ public final class HistoryViewModel: ViewModelable {
     var currentDate: Date = Date()
     var selectedDate: Date? = nil
     
+    var selectedIntakeHistoryID: String = ""
     var selectedProductID: String = ""
     var isMonthPickerPresented = false
     var isListPopupPresented: Bool { !selectedProductID.isEmpty }
@@ -60,7 +61,7 @@ public final class HistoryViewModel: ViewModelable {
     case loadHistoryForSelectedDate
     case datePickeronConfirm
     case updateCurrentDate(Date)
-    case updateSelectedProductID(String)
+    case updateSelectedProductID( String, String)
     case updateisMonthPickerPresented(Bool)
     case applySelectedDate(Date)
     case clearSelectedBeverage
@@ -87,11 +88,12 @@ public final class HistoryViewModel: ViewModelable {
     case .updateCurrentDate(let newDate):
       state.currentDate = newDate
       
-    case .updateSelectedProductID(let newId):
-      state.selectedProductID = newId
+    case .updateSelectedProductID(let intakeHistoryId,let productId):
+      state.selectedIntakeHistoryID = intakeHistoryId
+      state.selectedProductID = productId
       
     case .clearSelectedBeverage:
-      clearSelectedProductID()
+      clearSelectedItemID()
       
     case .updateisMonthPickerPresented(let isPickerPresented):
       state.isMonthPickerPresented = isPickerPresented
@@ -131,7 +133,7 @@ extension HistoryViewModel {
         await self.deleteSelectedBeverage()
       },
       secondaryButton: .init(title: "취소", type: .secondary) {
-        await self.clearSelectedProductID()
+        await self.clearSelectedItemID()
       }
     ))
   }
@@ -149,7 +151,7 @@ extension HistoryViewModel {
       
       if result {
         showToast(message: "삭제가 완료되었어요.", type: .success)
-        clearSelectedProductID()
+        clearSelectedItemID()
         await refreshData()
       } else {
         showToast(message: "데이터를 삭제할 수 없습니다.", type: .failure)
@@ -169,11 +171,12 @@ extension HistoryViewModel {
     state.selectedDateHistoryList = []
     state.totalSugarGrams = 0
     state.totalCount = 0
-    clearSelectedProductID()
+    clearSelectedItemID()
   }
   
-  private func clearSelectedProductID() {
+  private func clearSelectedItemID() {
     state.selectedProductID = ""
+    state.selectedIntakeHistoryID = ""
   }
   
   private func loadNetworkData() async {

--- a/HumanNeverDie/Projects/Features/HistoryFeature/Sources/HistoryViewModel.swift
+++ b/HumanNeverDie/Projects/Features/HistoryFeature/Sources/HistoryViewModel.swift
@@ -26,7 +26,7 @@ public final class HistoryViewModel: ViewModelable {
   
   public struct State: Equatable {
     var currentDate: Date = Date()
-    var selectedDate: Date? = nil
+    var selectedDate: Date? = Date.now
     
     var selectedIntakeHistoryID: String = ""
     var selectedProductID: String = ""
@@ -47,6 +47,8 @@ public final class HistoryViewModel: ViewModelable {
     var totalSugarGrams = 0
     var totalCount = 0
     
+    var isTodayOrPastSelectedDate: Bool { CommonFeature.isTodayOrPastSelectedDate(selectedDate) }
+
     var sugarStatus: BeverageSugarStatusType {
       let totalSugar = selectedDateCalendar?.totalSugarGrams ?? 0
       return .init(baseSugar: baseSugar, totalSugar: totalSugar)

--- a/HumanNeverDie/Projects/Features/HistoryFeature/Sources/HistoryViewModel.swift
+++ b/HumanNeverDie/Projects/Features/HistoryFeature/Sources/HistoryViewModel.swift
@@ -24,8 +24,8 @@ public final class HistoryViewModel: ViewModelable {
   @ObservationIgnored
   @Dependency(\.toastClient) private var toastClient
   
-  @ObservationIgnored
-  @Dependency(\.userDefaultClient) private var userDefaultClient
+//  @ObservationIgnored
+//  @Dependency(\.userDefaultClient) private var userDefaultClient
   
   public struct State: Equatable {
     var currentDate: Date = Date()
@@ -125,15 +125,15 @@ extension HistoryViewModel {
   }
   
   private func refreshData() async {
-    await loadBaseSugar()
+//    await loadBaseSugar()
     await loadNetworkData()
     loadSelectedDateHistory()
   }
   
-  private func loadBaseSugar() async {
-    let savedBaseSugar: Int = userDefaultClient.getValue(forKey: AMDUserDefaultKey.userMaxSugar) ?? 0
-    state.baseSugar = savedBaseSugar > 0 ? savedBaseSugar : 50
-  }
+//  private func loadBaseSugar() async {
+//    let savedBaseSugar: Int = userDefaultClient.getValue(forKey: AMDUserDefaultKey.userMaxSugar) ?? 0
+//    state.baseSugar = savedBaseSugar > 0 ? savedBaseSugar : 50
+//  }
   
   nonisolated private func showDeleteAlert() async {
     await alertClient.showAlert(.init(
@@ -198,7 +198,8 @@ extension HistoryViewModel {
     do {
       let dateString = Date.toRequestDateKeyString(from:state.currentDate)
       let result = try await beverageUseCase.getBeverageMonthCalender(dateInWeek: dateString)
-      
+
+      state.baseSugar = result[0].sugarMaxG
       let newSugarIntakeRecordData: [SugarIntakeRecord] = result.compactMap { dailyData in
         
         state.selectedDateCalendar = dailyData

--- a/HumanNeverDie/Projects/Features/HistoryFeature/Sources/HistoryViewModel.swift
+++ b/HumanNeverDie/Projects/Features/HistoryFeature/Sources/HistoryViewModel.swift
@@ -24,6 +24,9 @@ public final class HistoryViewModel: ViewModelable {
   @ObservationIgnored
   @Dependency(\.toastClient) private var toastClient
   
+  @ObservationIgnored
+  @Dependency(\.userDefaultClient) private var userDefaultClient
+  
   public struct State: Equatable {
     var currentDate: Date = Date()
     var selectedDate: Date? = Date.now
@@ -40,7 +43,6 @@ public final class HistoryViewModel: ViewModelable {
     var sugarIntakeRecordData: [SugarIntakeRecord] = []
     var monthHistoryData: [String: BeverageCalendar] = [:]
     
-    // 어디서 가져옴?
     var baseSugar: Int = 50
     var selectedDateCalendar: BeverageCalendar?
     
@@ -123,8 +125,14 @@ extension HistoryViewModel {
   }
   
   private func refreshData() async {
+    await loadBaseSugar()
     await loadNetworkData()
     loadSelectedDateHistory()
+  }
+  
+  private func loadBaseSugar() async {
+    let savedBaseSugar: Int = userDefaultClient.getValue(forKey: AMDUserDefaultKey.userMaxSugar) ?? 0
+    state.baseSugar = savedBaseSugar > 0 ? savedBaseSugar : 50
   }
   
   nonisolated private func showDeleteAlert() async {

--- a/HumanNeverDie/Projects/Features/HomeFeature/Sources/HomeView.swift
+++ b/HumanNeverDie/Projects/Features/HomeFeature/Sources/HomeView.swift
@@ -106,6 +106,7 @@ public struct HomeView: View {
       action: { router.push(to: .beverageRecordList(recordDate: viewModel.selectedDate ?? Date())) }
     )
     .padding(.bottom, 20)
+    .opacity(viewModel.state.isTodayOrPastSelectedDate ? 1 : 0)
   }
   
   private var datePickerBottomSheet: some View {

--- a/HumanNeverDie/Projects/Features/HomeFeature/Sources/HomeView.swift
+++ b/HumanNeverDie/Projects/Features/HomeFeature/Sources/HomeView.swift
@@ -23,6 +23,7 @@ public struct HomeView: View {
   
   public var body: some View {
     contentView
+      .padding(.top, 4)
       .background(.white)
       .amdBottomSheet(
         isPresented: $viewModel.state.isMonthPickerPresented,

--- a/HumanNeverDie/Projects/Features/HomeFeature/Sources/HomeView.swift
+++ b/HumanNeverDie/Projects/Features/HomeFeature/Sources/HomeView.swift
@@ -60,7 +60,7 @@ public struct HomeView: View {
     AMDCalendarFactory.createWeekly(
       currentDate: viewModel.currentDate,
       sugarIntakeRecordData: viewModel.sugarIntakeRecords,
-      userSugarTargetValue: 50,
+      userSugarTargetValue: $viewModel.state.baseSugar,
       selectedDate: $viewModel.state.selectedDate,
       onTapTitle: { viewModel.handleAction(.calendarChangeDateButtonTapped) },
       onWeekChanged: { viewModel.handleAction(.weekSlideGesture($0)) }

--- a/HumanNeverDie/Projects/Features/HomeFeature/Sources/HomeViewModel.swift
+++ b/HumanNeverDie/Projects/Features/HomeFeature/Sources/HomeViewModel.swift
@@ -30,6 +30,8 @@ public final class HomeViewModel: ViewModelable {
     var isSelectedDateEmpty: Bool = true
     
     var isMonthPickerPresented: Bool = false
+    
+    var isTodayOrPastSelectedDate: Bool { CommonFeature.isTodayOrPastSelectedDate(selectedDate) }
   }
   
   var sugarStatus: BeverageSugarStatusType {

--- a/HumanNeverDie/Projects/Features/HomeFeature/Sources/HomeViewModel.swift
+++ b/HumanNeverDie/Projects/Features/HomeFeature/Sources/HomeViewModel.swift
@@ -55,9 +55,6 @@ public final class HomeViewModel: ViewModelable {
   @ObservationIgnored
   @Dependency(\.beverageUseCase) private var beverageUseCase
   
-  @ObservationIgnored
-  @Dependency(\.userDefaultClient) private var userDefaultClient
-  
   public var state: State = .init()
   public init() {}
   
@@ -65,7 +62,6 @@ public final class HomeViewModel: ViewModelable {
     switch action {
     case .onViewDidLoad:
       Task {
-        await loadBaseSugar()
         await getWeeklyCalender()
       }
       
@@ -92,16 +88,12 @@ public final class HomeViewModel: ViewModelable {
     }
   }
   
-  private func loadBaseSugar() async {
-    let savedBaseSugar: Int = userDefaultClient.getValue(forKey: AMDUserDefaultKey.userMaxSugar) ?? 0
-    state.baseSugar = savedBaseSugar > 0 ? savedBaseSugar : 50
-  }
-  
   private func getWeeklyCalender() async {
     do {
       let dateString = Date.toRequestDateKeyString(from: state.currentDate)
       let result = try await beverageUseCase.getBeverageWeeklyCalender(dateInWeek: dateString)
       
+      state.baseSugar = result[0].sugarMaxG
       let newSugarIntakeRecordData: [SugarIntakeRecord] = result.compactMap { dailyData in
         let dateKey = dailyData.date.toYMDFormat
         state.weeklyHistories[dateKey] = dailyData

--- a/HumanNeverDie/Projects/Features/HomeFeature/Sources/HomeViewModel.swift
+++ b/HumanNeverDie/Projects/Features/HomeFeature/Sources/HomeViewModel.swift
@@ -24,7 +24,6 @@ public final class HomeViewModel: ViewModelable {
     var sugarIntakeRecords: [SugarIntakeRecord] = []
     var weeklyHistories: [String: BeverageCalendar] = [:]
     
-    // 어디서 가져옴?
     var baseSugar: Int = 50
     var selectedDateCalendar: BeverageCalendar?
     var isSelectedDateEmpty: Bool = true
@@ -56,13 +55,19 @@ public final class HomeViewModel: ViewModelable {
   @ObservationIgnored
   @Dependency(\.beverageUseCase) private var beverageUseCase
   
+  @ObservationIgnored
+  @Dependency(\.userDefaultClient) private var userDefaultClient
+  
   public var state: State = .init()
   public init() {}
   
   public func handleAction(_ action: Action) {
     switch action {
     case .onViewDidLoad:
-      Task { await getWeeklyCalender() }
+      Task {
+        await loadBaseSugar()
+        await getWeeklyCalender()
+      }
       
     case .calendarChangeDateButtonTapped:
       state.isMonthPickerPresented = true
@@ -85,6 +90,11 @@ public final class HomeViewModel: ViewModelable {
     case .homeRefresh:
       Task { await getWeeklyCalender() }
     }
+  }
+  
+  private func loadBaseSugar() async {
+    let savedBaseSugar: Int = userDefaultClient.getValue(forKey: AMDUserDefaultKey.userMaxSugar) ?? 0
+    state.baseSugar = savedBaseSugar > 0 ? savedBaseSugar : 50
   }
   
   private func getWeeklyCalender() async {

--- a/HumanNeverDie/Projects/Features/OnboardingFeature/Sources/Onboarding/OnboardingView.swift
+++ b/HumanNeverDie/Projects/Features/OnboardingFeature/Sources/Onboarding/OnboardingView.swift
@@ -121,7 +121,6 @@ extension OnboardingView {
     var body: some View {
       GeometryReader { geometry in
         VStack(spacing: 0) {
-          // 텍스트 영역 - 화면의 20-25%
           VStack {
             Text(title)
               .amdFont(.xxlargeBold)
@@ -129,8 +128,7 @@ extension OnboardingView {
               .multilineTextAlignment(.center)
           }
           .frame(height: geometry.size.height * 0.25)
-          
-          // 이미지 영역 - 화면의 75%
+      
           image.swiftUIImage
             .resizable()
             .scaledToFit()

--- a/HumanNeverDie/Projects/Features/OnboardingFeature/Sources/OnboardingProfile/Components/OnboardingComponents.swift
+++ b/HumanNeverDie/Projects/Features/OnboardingFeature/Sources/OnboardingProfile/Components/OnboardingComponents.swift
@@ -27,6 +27,8 @@ public struct OnboardingTopHeaderView: View {
         .multilineTextAlignment(.trailing)
     }
     .padding(.horizontal, 20)
+    .padding(.top, 20)
+    
   }
 }
 

--- a/HumanNeverDie/Projects/Features/OnboardingFeature/Sources/OnboardingProfile/OnboardingProfileViewModel.swift
+++ b/HumanNeverDie/Projects/Features/OnboardingFeature/Sources/OnboardingProfile/OnboardingProfileViewModel.swift
@@ -128,11 +128,10 @@ public final class OnboardingProfileViewModel: ViewModelable {
     }
   }
   
-  public func updateNotificationSetting(isEnabled: Bool) async {
+  public func updateUseNotiInfo(isEnabled: Bool) async {
     do {
-      let notiInfo = UserNotifications.defaultUserNotifications(isEnabled: isEnabled)
-      _ = try await userUseCase.updateUserNotifications(userID: state.userID, userNotifications: notiInfo)
-      print("✅ 알림 설정 업데이트 성공: \(isEnabled)")
+      let result = try await userUseCase.updateNotifications(userID: state.userID, isEnabled: isEnabled)
+      print("✅ 알림 설정 업데이트 성공: \(result.isEnabled)")
     } catch {
       print("❌ 알림 설정 업데이트 실패: \(error)")
     }
@@ -157,7 +156,7 @@ extension OnboardingProfileViewModel {
         state.isPermissionGranted = granted
       }
       
-      await updateNotificationSetting(isEnabled: granted)
+      await updateUseNotiInfo(isEnabled: granted)
       
       if !granted {
         await showPermissionDeniedAlert()
@@ -166,7 +165,7 @@ extension OnboardingProfileViewModel {
       await MainActor.run {
         state.isPermissionGranted = false
       }
-      await updateNotificationSetting(isEnabled: false)
+      await updateUseNotiInfo(isEnabled: false)
       await showPermissionDeniedAlert()
     }
   }

--- a/HumanNeverDie/Projects/Features/OnboardingFeature/Sources/OnboardingProfile/StepsView/BasicInfoFormView.swift
+++ b/HumanNeverDie/Projects/Features/OnboardingFeature/Sources/OnboardingProfile/StepsView/BasicInfoFormView.swift
@@ -82,7 +82,7 @@ extension BasicInfoFormView {
       contentGenderSection()
     }
     .padding(.horizontal, 20)
-    .padding(.top, 48)
+    .padding(.top, 28)
   }
   
   @ViewBuilder

--- a/HumanNeverDie/Projects/Features/OnboardingFeature/Sources/OnboardingProfile/StepsView/DailySugarGoalView.swift
+++ b/HumanNeverDie/Projects/Features/OnboardingFeature/Sources/OnboardingProfile/StepsView/DailySugarGoalView.swift
@@ -131,13 +131,27 @@ extension DailySugarGoalView {
   @ViewBuilder
   private func bottomInfoView() -> some View {
     VStack(alignment: .leading, spacing: 8) {
-      Text("아맞당은 *WHO 세계 표준 권장 당류 가이드라인을 기준으로 일일 권장 당 섭취량을 산출하고 있어요.")
-        .amdFont(.xsmallRegular)
-        .foregroundColor(.gray50)
+      HStack(spacing: 4) {
+        Text("권장 당 섭취량 계산법이 궁금하다면?")
+          .amdFont(.xsmallRegular)
+          .foregroundColor(.gray85)
+          .underline()
+        
+        Image(systemName: "chevron.right")
+          .font(.system(size: 10))
+          .foregroundColor(.gray70)
+      }.onTapGesture {
+        viewModel.handleAction(.showSugarCalculationInfo)
+      }
+      .amdBottomSheet(isPresented: $viewModel.state.isShowingSugarCalculationInfo, detents: [.height(800)]) {
+        SugarCalculationInfoContent {
+          viewModel.handleAction(.hideSugarCalculationInfo)
+        }
+      }
       
-      Text("*WHO 세계 권장 당류 가이드라인: 1일 에너지 필요량의 10%")
+      Text("*아맞당은 카페 음료의 당류만 기록해요. 식사나 간식 등 다른 경로로 섭취 한 당류는 고려하지 않으니 참고해주세요.")
         .amdFont(.xsmallRegular)
-        .foregroundColor(.gray50)
+        .foregroundColor(.gray60)
     }
     .padding(.top, 24)
     .padding(.horizontal, 20)

--- a/HumanNeverDie/Projects/Features/OnboardingFeature/Sources/OnboardingProfile/StepsView/DailySugarGoalView.swift
+++ b/HumanNeverDie/Projects/Features/OnboardingFeature/Sources/OnboardingProfile/StepsView/DailySugarGoalView.swift
@@ -53,7 +53,7 @@ extension DailySugarGoalView {
       goalSelectionView()
     }
     .padding(.horizontal, 20)
-    .padding(.top, 30)
+    .padding(.top, 20)
   }
   
   @ViewBuilder

--- a/HumanNeverDie/Projects/Features/OnboardingFeature/Sources/OnboardingProfile/StepsView/DailySugarGoalViewModel.swift
+++ b/HumanNeverDie/Projects/Features/OnboardingFeature/Sources/OnboardingProfile/StepsView/DailySugarGoalViewModel.swift
@@ -18,6 +18,7 @@ public final class DailySugarGoalViewModel: ViewModelable {
     var selectedDailySugarGoal: SugarGoal = .none
     
     var showAlert: Bool = false
+    var isShowingSugarCalculationInfo: Bool = false
   }
   
   public enum Action {
@@ -25,6 +26,9 @@ public final class DailySugarGoalViewModel: ViewModelable {
     case updateDailySugarGoal(SugarGoal)
     case submitGoalInfo
     case showCalculationModal(Bool)
+    
+    case showSugarCalculationInfo
+    case hideSugarCalculationInfo
   }
   
   public var state: State = .init()
@@ -48,6 +52,11 @@ public final class DailySugarGoalViewModel: ViewModelable {
       parentViewModel?.proceedToNextStep()
     case .showCalculationModal(let isShow):
       state.showAlert = isShow
+    case .showSugarCalculationInfo:
+      state.isShowingSugarCalculationInfo = true
+      
+    case .hideSugarCalculationInfo:
+      state.isShowingSugarCalculationInfo = false
     }
   }
   

--- a/HumanNeverDie/Projects/Features/OnboardingFeature/Sources/OnboardingProfile/StepsView/PermissionViewModel.swift
+++ b/HumanNeverDie/Projects/Features/OnboardingFeature/Sources/OnboardingProfile/StepsView/PermissionViewModel.swift
@@ -59,14 +59,14 @@ public final class PermissionViewModel: ViewModelable {
         state.isPermissionGranted = granted
       }
       
-      await parentViewModel?.updateNotificationSetting(isEnabled: granted)
+      await parentViewModel?.updateUseNotiInfo(isEnabled: granted)
       
     } catch {
       await MainActor.run {
         state.isPermissionGranted = false
       }
       
-      await parentViewModel?.updateNotificationSetting(isEnabled: false)
+      await parentViewModel?.updateUseNotiInfo(isEnabled: false)
     }
   }
 }

--- a/HumanNeverDie/Projects/Features/OnboardingFeature/Sources/OnboardingProfile/StepsView/PermissionViewModel.swift
+++ b/HumanNeverDie/Projects/Features/OnboardingFeature/Sources/OnboardingProfile/StepsView/PermissionViewModel.swift
@@ -12,7 +12,7 @@ import CommonFeature
 @Observable
 @MainActor
 public final class PermissionViewModel: ViewModelable {
-  private var parentViewModel: OnboardingProfileViewModel?
+  private weak var parentViewModel: OnboardingProfileViewModel?
   
   public struct State: Equatable {
     var isPermissionGranted: Bool = false

--- a/HumanNeverDie/Projects/Features/OnboardingFeature/Sources/OnboardingProfile/StepsView/PhysicalInfoFormView.swift
+++ b/HumanNeverDie/Projects/Features/OnboardingFeature/Sources/OnboardingProfile/StepsView/PhysicalInfoFormView.swift
@@ -30,6 +30,7 @@ struct PhysicalInfoFormView: View {
     .onAppear {
       viewModel.handleAction(.onAppear)
     }
+    .toolbarVisibility(.hidden, for: .navigationBar)
   }
 }
 
@@ -78,7 +79,7 @@ extension PhysicalInfoFormView {
       contentActivitySection()
     }
     .padding(.horizontal, 20)
-    .padding(.top, 48)
+    .padding(.top, 28)
   }
   
   @ViewBuilder

--- a/HumanNeverDie/Projects/Features/SettingFeature/Sources/SettingView.swift
+++ b/HumanNeverDie/Projects/Features/SettingFeature/Sources/SettingView.swift
@@ -72,7 +72,7 @@ public struct SettingView: View {
       sectionDivider().padding(.vertical, 16)
       
       VStack(alignment: .leading, spacing:0) {
-        AppVersionRow(title: "앱 버전", value: "0.0.0")
+        AppVersionRow(title: "앱 버전", value: "1.0.1") // 추후 appID발행 후 로직 개발진행
       }.padding(.horizontal, 20)
       
       Spacer()

--- a/HumanNeverDie/Projects/Features/SettingFeature/Sources/SettingViewModel.swift
+++ b/HumanNeverDie/Projects/Features/SettingFeature/Sources/SettingViewModel.swift
@@ -21,8 +21,6 @@ public final class SettingViewModel: ViewModelable {
   @Dependency(\.toastClient) private var toastClient
   @ObservationIgnored
   @Dependency(\.alertClient) private var alertClient
-  @ObservationIgnored
-  @Dependency(\.userDefaultClient) private var userDefaultClient
   
   public struct State: Equatable {
     var userInfo: UserInfo
@@ -101,8 +99,6 @@ extension SettingViewModel {
       
       showToast(message: "저장이 완료되었어요", type: .success)
       setUserInfo(userInfo: result)
-      
-      await userDefaultClient.setValue(state.sugarMaxG, forKey: AMDUserDefaultKey.userMaxSugar)
       
       state.isLoading = false
       

--- a/HumanNeverDie/Projects/Features/SettingFeature/Sources/SettingViewModel.swift
+++ b/HumanNeverDie/Projects/Features/SettingFeature/Sources/SettingViewModel.swift
@@ -21,6 +21,8 @@ public final class SettingViewModel: ViewModelable {
   @Dependency(\.toastClient) private var toastClient
   @ObservationIgnored
   @Dependency(\.alertClient) private var alertClient
+  @ObservationIgnored
+  @Dependency(\.userDefaultClient) private var userDefaultClient
   
   public struct State: Equatable {
     var userInfo: UserInfo
@@ -99,14 +101,16 @@ extension SettingViewModel {
       
       showToast(message: "저장이 완료되었어요", type: .success)
       setUserInfo(userInfo: result)
-      state.sugarMaxG = result.sugarMaxG
+      
+      await userDefaultClient.setValue(state.sugarMaxG, forKey: AMDUserDefaultKey.userMaxSugar)
+      
+      state.isLoading = false
       
     } catch {
       showToast(message: "저장에 실패하였습니다", type: .failure)
       state.isLoading = false
     }
   }
-  
   private func showToast(message: String, type: AMDToastType) {
     Task { @MainActor in
       await toastClient.showToast(.init(message: message, type: type))

--- a/HumanNeverDie/Projects/Features/SettingFeature/Sources/StepsView/AccountInfoView.swift
+++ b/HumanNeverDie/Projects/Features/SettingFeature/Sources/StepsView/AccountInfoView.swift
@@ -97,6 +97,10 @@ extension AccountInfoView {
         viewModel.state.showAlert = true
       }
     )
+    .disabled(true)
+    .onTapGesture {
+      viewModel.state.showAlert = true
+    }
   }
   
   @ViewBuilder

--- a/HumanNeverDie/Projects/Features/SettingFeature/Sources/StepsView/GoalSettingView.swift
+++ b/HumanNeverDie/Projects/Features/SettingFeature/Sources/StepsView/GoalSettingView.swift
@@ -32,7 +32,7 @@ public struct GoalSettingView: View {
       self.router.pop()
     }
     .onAppear {
-        viewModel.setRouter(router)
+      viewModel.setRouter(router)
     }
   }
 }
@@ -122,13 +122,27 @@ extension GoalSettingView {
   @ViewBuilder
   private func bottomInfoView() -> some View {
     VStack(alignment: .leading, spacing: 8) {
-      Text("아맞당은 *WHO 세계 표준 권장 당류 가이드라인을 기준으로 일일 권장 당 섭취량을 산출하고 있어요.")
-        .amdFont(.xsmallRegular)
-        .foregroundColor(.gray50)
+      HStack(spacing: 4) {
+        Text("권장 당 섭취량 계산법이 궁금하다면?")
+          .amdFont(.xsmallRegular)
+          .foregroundColor(.gray85)
+          .underline()
+        
+        Image(systemName: "chevron.right")
+          .font(.system(size: 10))
+          .foregroundColor(.gray70)
+      }.onTapGesture {
+        viewModel.handleAction(.showSugarCalculationInfo)
+      }
+      .amdBottomSheet(isPresented: $viewModel.state.isShowingSugarCalculationInfo, detents: [.height(800)]) {
+        SugarCalculationInfoContent {
+          viewModel.handleAction(.hideSugarCalculationInfo)
+        }
+      }
       
-      Text("*WHO 세계 권장 당류 가이드라인: 1일 에너지 필요량의 10%")
+      Text("*아맞당은 카페 음료의 당류만 기록해요. 식사나 간식 등 다른 경로로 섭취 한 당류는 고려하지 않으니 참고해주세요.")
         .amdFont(.xsmallRegular)
-        .foregroundColor(.gray50)
+        .foregroundColor(.gray60)
     }
     .padding(.top, 24)
     .padding(.horizontal, 20)

--- a/HumanNeverDie/Projects/Features/SettingFeature/Sources/StepsView/GoalSettingViewModel.swift
+++ b/HumanNeverDie/Projects/Features/SettingFeature/Sources/StepsView/GoalSettingViewModel.swift
@@ -23,6 +23,7 @@ public final class GoalSettingViewModel: ViewModelable {
   public struct State: Equatable, Sendable {
     var userInfo: UserInfo
     var selectedDailySugarGoal: SugarGoal
+    var isShowingSugarCalculationInfo: Bool = false
   }
   
   public enum Action {
@@ -30,6 +31,9 @@ public final class GoalSettingViewModel: ViewModelable {
     case updateDailySugarGoal(SugarGoal)
     
     case updateAccountInfoUserInfo
+    
+    case showSugarCalculationInfo
+    case hideSugarCalculationInfo
   }
   
   public var state: State
@@ -60,6 +64,11 @@ public final class GoalSettingViewModel: ViewModelable {
         await showSaveAlert()
       }
       break
+    case .showSugarCalculationInfo:
+      state.isShowingSugarCalculationInfo = true
+      
+    case .hideSugarCalculationInfo:
+      state.isShowingSugarCalculationInfo = false
     }
   }
 }
@@ -67,7 +76,7 @@ public final class GoalSettingViewModel: ViewModelable {
 // MARK: - Goal Setting Specific Methods
 extension GoalSettingViewModel {
   public func setRouter(_ router: Router) {
-      self.router = router
+    self.router = router
   }
   
   public func getSugarGoalAmount(for goal: SugarGoal) -> Int {
@@ -90,6 +99,9 @@ extension GoalSettingViewModel {
   }
   
   public var isChangedAccountInfo: Bool {
+    if (state.isShowingSugarCalculationInfo) {
+      return false
+    }
     return state != originalState
   }
   
@@ -98,34 +110,34 @@ extension GoalSettingViewModel {
   }
   
   nonisolated private func showSaveAlert() async {
-      await alertClient.showAlert(.init(
-        title: "목표를 정말 변경하시겠어요?",
-        message: "목표 설정 수정 시, 일일 당 섭취 목표가 즉시 변경될 예정이에요.",
-        primaryButton: .init(title: "저장", type: .default) {
-          Task { @MainActor in
-            // 🔵 수정: UserInfo 전체를 새로 생성해서 전달
-            let updatedUserInfo = UserInfo(
-              nickname: self.state.userInfo.nickname,
-              birthDate: self.state.userInfo.birthDate,
-              selectedGender: self.state.userInfo.selectedGender,
-              height: self.state.userInfo.height,
-              weight: self.state.userInfo.weight,
-              selectedActivity: self.state.userInfo.selectedActivity,
-              selectedDailySugarGoal: self.state.selectedDailySugarGoal
-            )
-            
-            await MainActor.run {
-              self.router?.onUserInfoUpdated?(updatedUserInfo)
-              self.router?.pop()
-            }
-          }
-        },
-        secondaryButton: .init(title: "취소", type: .secondary) {
-          // 취소 시 원래 값으로 되돌리기
-          Task { @MainActor in
-            self.state.selectedDailySugarGoal = self.originalState.selectedDailySugarGoal
+    await alertClient.showAlert(.init(
+      title: "목표를 정말 변경하시겠어요?",
+      message: "목표 설정 수정 시, 일일 당 섭취 목표가 즉시 변경될 예정이에요.",
+      primaryButton: .init(title: "저장", type: .default) {
+        Task { @MainActor in
+          // 🔵 수정: UserInfo 전체를 새로 생성해서 전달
+          let updatedUserInfo = UserInfo(
+            nickname: self.state.userInfo.nickname,
+            birthDate: self.state.userInfo.birthDate,
+            selectedGender: self.state.userInfo.selectedGender,
+            height: self.state.userInfo.height,
+            weight: self.state.userInfo.weight,
+            selectedActivity: self.state.userInfo.selectedActivity,
+            selectedDailySugarGoal: self.state.selectedDailySugarGoal
+          )
+          
+          await MainActor.run {
+            self.router?.onUserInfoUpdated?(updatedUserInfo)
+            self.router?.pop()
           }
         }
-      ))
-    }
+      },
+      secondaryButton: .init(title: "취소", type: .secondary) {
+        // 취소 시 원래 값으로 되돌리기
+        Task { @MainActor in
+          self.state.selectedDailySugarGoal = self.originalState.selectedDailySugarGoal
+        }
+      }
+    ))
+  }
 }

--- a/HumanNeverDie/Projects/Features/SettingFeature/Sources/StepsView/NotificationSettingView.swift
+++ b/HumanNeverDie/Projects/Features/SettingFeature/Sources/StepsView/NotificationSettingView.swift
@@ -38,11 +38,20 @@ public struct NotificationSettingView: View {
       ) {
         viewModel.handleAction(.updateReminderTime($0))
       }
-
-    }.settingToolbar(item: .notificationSetting) {
+    }
+    .settingToolbar(item: .notificationSetting) {
       self.router.pop()
     }
-
+    .alert("알림 권한이 필요합니다", isPresented: $viewModel.state.showPermissionAlert) {
+      Button("설정으로 이동") {
+        viewModel.handleAction(.openSystemSettings)
+      }
+      Button("취소", role: .cancel) {
+        viewModel.handleAction(.dismissAlert)
+      }
+    } message: {
+      Text("알림 설정을 변경하려면 설정에서 알림 권한을 허용해주세요.")
+    }
   }
 }
 
@@ -146,8 +155,8 @@ private struct NotificationToggleRow: View {
         
         if let subtitle = subtitle {
           Text(subtitle)
-            .lineLimit(1)
-            .fixedSize(horizontal: true, vertical: false)
+            .lineLimit(nil)
+            .fixedSize(horizontal: false, vertical: true)
             .amdFont(.xsmallRegular)
             .foregroundColor(.gray60)
             .opacity(isEnabled ? 1.0 : 0.4)

--- a/HumanNeverDie/Projects/Features/SettingFeature/Sources/StepsView/NotificationSettingViewModel.swift
+++ b/HumanNeverDie/Projects/Features/SettingFeature/Sources/StepsView/NotificationSettingViewModel.swift
@@ -109,7 +109,7 @@ extension NotificationSettingViewModel {
     do {
       let result = try await userUseCase.getUserNotificationInfo(userID: state.userID)
       state.notiInfo = result
-
+      
       setLoading(false)
       
     } catch {
@@ -124,10 +124,8 @@ extension NotificationSettingViewModel {
     
     switch settingType {
     case .isEnabled(let isEnabled):
-      current.isEnabled = isEnabled
-      current.remindersEnabled = isEnabled
-      current.riskWarningsEnabled = isEnabled
-      current.newsUpdatesEnabled = isEnabled
+      await updateUseNotiInfo(isEnabled: isEnabled)
+      return
       
     case .remindersEnabled(let isEnabled):
       current.remindersEnabled = isEnabled
@@ -143,6 +141,22 @@ extension NotificationSettingViewModel {
     }
     
     await updateNotiInfo(notiInfo: current)
+  }
+  
+  private func updateUseNotiInfo(isEnabled: Bool) async {
+    setLoading(true)
+    
+    do {
+      let result = try await userUseCase.updateNotifications(userID: state.userID, isEnabled: isEnabled)
+      state.notiInfo = result
+      
+      setLoading(false)
+      
+    } catch {
+      showToast(message: "오류가 발생했어요. 다시 시도해주세요.", type: .failure)
+      
+      setLoading(false)
+    }
   }
   
   private func updateNotiInfo(notiInfo: UserNotifications) async {

--- a/HumanNeverDie/Projects/Features/SettingFeature/Sources/StepsView/NotificationSettingViewModel.swift
+++ b/HumanNeverDie/Projects/Features/SettingFeature/Sources/StepsView/NotificationSettingViewModel.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+import UserNotifications
 import UserDomain
+import UIKit
 
 import DesignSystem
 import CommonFeature
@@ -34,6 +36,9 @@ public final class NotificationSettingViewModel: ViewModelable {
     var showTimePicker: Bool = false
     var isLoading: Bool = false
     var notiInfo: UserNotifications = UserNotifications.mock()
+
+    var systemPermissionGranted: Bool = false
+    var showPermissionAlert: Bool = false
   }
   
   public var state: State
@@ -47,6 +52,8 @@ public final class NotificationSettingViewModel: ViewModelable {
   public enum Action {
     case onAppear
     case loadUserInfo
+    case openSystemSettings
+    case dismissAlert
     
     case toggleIsEnabled(Bool)
     case toggleRemindersEnabled(Bool)
@@ -57,7 +64,6 @@ public final class NotificationSettingViewModel: ViewModelable {
   
   public init(userID: String) {
     let initialState = State(userID: userID)
-    
     self.state = initialState
   }
   
@@ -68,8 +74,16 @@ public final class NotificationSettingViewModel: ViewModelable {
       
     case .loadUserInfo:
       Task {
+        await checkSystemNotificationPermission()
         await loadUserData()
       }
+      
+    case .openSystemSettings:
+      openSystemSettings()
+      state.showPermissionAlert = false
+      
+    case .dismissAlert:
+      state.showPermissionAlert = false
       
     case .toggleIsEnabled(let isEnabled):
       Task {
@@ -108,8 +122,12 @@ extension NotificationSettingViewModel {
     
     do {
       let result = try await userUseCase.getUserNotificationInfo(userID: state.userID)
-      state.notiInfo = result
-      
+      if (!state.systemPermissionGranted && result.isEnabled) {
+        await updateUseNotiInfo(isEnabled: false)
+      } else {
+        state.notiInfo = result
+      }
+  
       setLoading(false)
       
     } catch {
@@ -119,28 +137,63 @@ extension NotificationSettingViewModel {
     }
   }
   
-  private func updateNotiSetting(_ settingType: NotiSettingType) async {
-    var current = state.notiInfo
+  nonisolated private func checkSystemNotificationPermission() async {
+    let center = UNUserNotificationCenter.current()
+    let settings = await center.notificationSettings()
+    let isAuthorized = settings.authorizationStatus == .authorized
     
-    switch settingType {
-    case .isEnabled(let isEnabled):
-      await updateUseNotiInfo(isEnabled: isEnabled)
+    await MainActor.run {
+      state.systemPermissionGranted = isAuthorized
+    }
+  }
+  
+  private func openSystemSettings() {
+    guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
+      showToast(message: "설정을 열 수 없습니다.", type: .failure)
       return
-      
-    case .remindersEnabled(let isEnabled):
-      current.remindersEnabled = isEnabled
-      
-    case .riskWarningsEnabled(let isEnabled):
-      current.riskWarningsEnabled = isEnabled
-      
-    case .newsUpdatesEnabled(let isEnabled):
-      current.newsUpdatesEnabled = isEnabled
-      
-    case .reminderTime(let time):
-      current.reminderTime = current.convertDateToTimeString(time)
     }
     
-    await updateNotiInfo(notiInfo: current)
+    if UIApplication.shared.canOpenURL(settingsUrl) {
+      UIApplication.shared.open(settingsUrl) { [weak self] success in
+        if success {
+          // 설정에서 돌아왔을 때 권한 상태 다시 확인
+          Task { @MainActor in
+            await self?.checkSystemNotificationPermission()
+          }
+        }
+      }
+    } else {
+      showToast(message: "설정을 열 수 없습니다.", type: .failure)
+    }
+  }
+  
+  private func updateNotiSetting(_ settingType: NotiSettingType) async {
+    if (state.systemPermissionGranted == false) {
+      state.showPermissionAlert = true
+    }else {
+      
+      var current = state.notiInfo
+      
+      switch settingType {
+      case .isEnabled(let isEnabled):
+        await updateUseNotiInfo(isEnabled: isEnabled)
+        return
+        
+      case .remindersEnabled(let isEnabled):
+        current.remindersEnabled = isEnabled
+        
+      case .riskWarningsEnabled(let isEnabled):
+        current.riskWarningsEnabled = isEnabled
+        
+      case .newsUpdatesEnabled(let isEnabled):
+        current.newsUpdatesEnabled = isEnabled
+        
+      case .reminderTime(let time):
+        current.reminderTime = current.convertDateToTimeString(time)
+      }
+      
+      await updateNotiInfo(notiInfo: current)
+    }
   }
   
   private func updateUseNotiInfo(isEnabled: Bool) async {
@@ -179,11 +232,9 @@ extension NotificationSettingViewModel {
     state.isLoading = isLoading
   }
   
-  
   private func showToast(message: String, type: AMDToastType) {
     Task { @MainActor in
       await toastClient.showToast(.init(message: message, type: type))
     }
   }
-  
 }

--- a/HumanNeverDie/Projects/Features/SettingFeature/Sources/StepsView/TermsView.swift
+++ b/HumanNeverDie/Projects/Features/SettingFeature/Sources/StepsView/TermsView.swift
@@ -20,11 +20,11 @@ public struct TermsView: View {
     List {
       Section {
         TermsRow(title: "이용약관") {
-          //페이지 이동
+          openURL("https://telling-abrosaurus-7ba.notion.site/24d0d89bf00580b08fcad69f40cf98ae")
         }
 
         TermsRow(title: "개인정보처리방침") {
-          //외부링크 이동
+          openURL("https://telling-abrosaurus-7ba.notion.site/24d0d89bf00580dc8277f6fa24888796?pvs=74")
         }
       }.padding(.horizontal, 20)
     }.settingToolbar(item: .notificationSetting) {
@@ -32,6 +32,11 @@ public struct TermsView: View {
     }
     .listStyle(.plain)
     .listRowSeparator(.hidden)
+  }
+  
+  private func openURL(_ urlString: String) {
+    guard let url = URL(string: urlString) else { return }
+    UIApplication.shared.open(url)
   }
 }
 

--- a/HumanNeverDie/Projects/Features/SplashFeature/Sources/SplashViewModel.swift
+++ b/HumanNeverDie/Projects/Features/SplashFeature/Sources/SplashViewModel.swift
@@ -41,7 +41,6 @@ public final class SplashViewModel: ViewModelable {
     switch action {
     case .onAppear:
       Task {
-        await getUserMaxSugar()
         await syncLocalLikeToServer()
         await setInitializationCompleted()
       }
@@ -81,19 +80,6 @@ public final class SplashViewModel: ViewModelable {
       }
     } catch {
       print("로컬 데이터 조회 실패")
-    }
-  }
-  
-  private func getUserMaxSugar() async {
-    do {
-      let result = try await beverageUseCase.getBeveragDailyCalender(dailyDate: "1999-01-01T17:30:00")
-      
-      // 시스템 권장값 저장
-      await userDefaultClient.setValue(result.sugarMaxG, forKey: AMDUserDefaultKey.userMaxSugar)
-      print("API 호출 성공 - systemMaxSugar: \(result.sugarMaxG) 저장 완료")
-      
-    } catch {
-      print("API 호출 실패: \(error)")
     }
   }
   

--- a/HumanNeverDie/Projects/Features/SplashFeature/Sources/SplashViewModel.swift
+++ b/HumanNeverDie/Projects/Features/SplashFeature/Sources/SplashViewModel.swift
@@ -10,6 +10,7 @@ import Observation
 
 import CommonFeature
 import BeverageDomain
+import Shared
 
 import Dependencies
 
@@ -30,6 +31,9 @@ public final class SplashViewModel: ViewModelable {
   @ObservationIgnored
   @Dependency(\.beverageLocalLikeUseCase) private var beverageLocalLikeUseCase
   
+  @ObservationIgnored
+  @Dependency(\.userDefaultClient) private var userDefaultClient
+  
   public var state: State = .init()
   public init() {}
   
@@ -37,6 +41,7 @@ public final class SplashViewModel: ViewModelable {
     switch action {
     case .onAppear:
       Task {
+        await getUserMaxSugar()
         await syncLocalLikeToServer()
         await setInitializationCompleted()
       }
@@ -76,6 +81,19 @@ public final class SplashViewModel: ViewModelable {
       }
     } catch {
       print("로컬 데이터 조회 실패")
+    }
+  }
+  
+  private func getUserMaxSugar() async {
+    do {
+      let result = try await beverageUseCase.getBeveragDailyCalender(dailyDate: "1999-01-01T17:30:00")
+      
+      // 시스템 권장값 저장
+      await userDefaultClient.setValue(result.sugarMaxG, forKey: AMDUserDefaultKey.userMaxSugar)
+      print("API 호출 성공 - systemMaxSugar: \(result.sugarMaxG) 저장 완료")
+      
+    } catch {
+      print("API 호출 실패: \(error)")
     }
   }
   

--- a/HumanNeverDie/Projects/Shared/Shared/Sources/Client/AMDUserDefaultClient/AMDUserDefaultKey.swift
+++ b/HumanNeverDie/Projects/Shared/Shared/Sources/Client/AMDUserDefaultClient/AMDUserDefaultKey.swift
@@ -7,4 +7,5 @@
 
 public enum AMDUserDefaultKey {
   public static let recentSearchList = "recentSearchList"
+  public static let userMaxSugar = "userMaxSugar"
 }

--- a/HumanNeverDie/Projects/Shared/Shared/Sources/Client/AMDUserDefaultClient/AMDUserDefaultKey.swift
+++ b/HumanNeverDie/Projects/Shared/Shared/Sources/Client/AMDUserDefaultClient/AMDUserDefaultKey.swift
@@ -7,5 +7,4 @@
 
 public enum AMDUserDefaultKey {
   public static let recentSearchList = "recentSearchList"
-  public static let userMaxSugar = "userMaxSugar"
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Resolved: #85 

## 🛠️ 작업한 내용
* 캘린더 UTC → KST 변환 로직 개선
    * iOS Date는 기본적으로 UTC 기준으로 동작하기 때문에 캘린더에서 단순히 +9h 보정만 하면 날짜·시간이 불일치하는 문제가 발생함
    * 특히 SelectDate가 "날짜만" 들고 있고 "현재 시간"을 포함하지 않아, 변환 시 KST 보정 후에도 정확한 값이 맞지 않는 현상이 있었음
    * 이를 해결하기 위해 캘린더 SelectDate에 현재 시간 데이터를 추가하여 UTC → KST 변환 시 올바른 시간대로 저장되도록 수정함
    * 또한 음료 등록시 ISO8601Format사용하는데 KTC로 변환하여 서버에 넘겨주는 로직으로 변경함
* 온보딩 코드리뷰 사항 반영
* 히스토리 추가 로직 수정
* 히스토리 리스트에서 음료 선택 시 발생하던 버그 수정

## 📸 스크린샷(선택)
|    1    |   2   |
| :-------------: | :----------: |
|  |  |

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

