### PR TITLE
Feature/#106

### DIFF
--- a/HumanNeverDie/Projects/CommonFeature/DesignSystem/Sources/Components/AMDDatePicker/AMDDatePickerViewController.swift
+++ b/HumanNeverDie/Projects/CommonFeature/DesignSystem/Sources/Components/AMDDatePicker/AMDDatePickerViewController.swift
@@ -13,7 +13,7 @@ private struct AMDDatePickerConstants {
   fileprivate static let months = Array(1...12)
   fileprivate static let amPmOptions = ["오전", "오후"]
   fileprivate static let hours12 = Array(1...12)
-  fileprivate static let minutes = Array(0...59)
+  fileprivate static let minutes = Array(stride(from: 0, to: 60, by: 5))
   
   fileprivate static let pickerViewRows = 10_000
   fileprivate static let pickerViewMiddle = ((pickerViewRows / hours12.count) / 2) * hours12.count
@@ -207,7 +207,11 @@ private extension AMDDatePickerViewController {
       let targetRow = rowForHourValue(currentDate.displayHour12)
       picker.selectRow(targetRow, inComponent: 1, animated: false)
       
-      picker.selectRow(currentDate.minute, inComponent: 2, animated: false)
+      // 현재 분을 5분 단위로 반올림해서 가장 가까운 값 선택
+      let currentMinute = currentDate.minute
+      let roundedMinute = (currentMinute / 5) * 5 // 5분 단위로 반올림
+      let minuteIndex = AMDDatePickerConstants.minutes.firstIndex(of: roundedMinute) ?? 0
+      picker.selectRow(minuteIndex, inComponent: 2, animated: false)
     }
   }
   
@@ -309,7 +313,7 @@ private extension AMDDatePickerViewController {
     }
   }
   
-  func updateSelectedTime(_ pickerView: UIPickerView) {
+  private func updateSelectedTime(_ pickerView: UIPickerView) {
     let calendar = Calendar.current
     
     // 기존 날짜 정보 유지
@@ -323,7 +327,7 @@ private extension AMDDatePickerViewController {
     let hourRow = pickerView.selectedRow(inComponent: 1)
     let hour12 = hourValueForRow(hourRow)
     
-    // 분
+    // 분 (5분 단위)
     let minuteRow = pickerView.selectedRow(inComponent: 2)
     let minute = AMDDatePickerConstants.minutes[minuteRow]
     
@@ -344,6 +348,7 @@ private extension AMDDatePickerViewController {
       onDateChanged?(newDate)
     }
   }
+
   
   func getSelectedYear(_ pickerView: UIPickerView) -> Int {
     let yearIndex = pickerView.selectedRow(inComponent: 0)

--- a/HumanNeverDie/Projects/Domain/UserDomain/Sources/ServerSugerOfficial/SugarUserCalculation.swift
+++ b/HumanNeverDie/Projects/Domain/UserDomain/Sources/ServerSugerOfficial/SugarUserCalculation.swift
@@ -66,7 +66,7 @@ public class SugarUserCalculation {
       finalSugarGoal = 0
     }
     
-    return Int(finalSugarGoal.rounded(.up))
+    return Int(finalSugarGoal.rounded(.down))
   }
   
   public func calculate(for userInfo: UserInfo) -> RecommendedSugar {

--- a/HumanNeverDie/Projects/Features/BeverageRecordListFeature/Sources/BeverageRecord/BeverageRecordViewModel.swift
+++ b/HumanNeverDie/Projects/Features/BeverageRecordListFeature/Sources/BeverageRecord/BeverageRecordViewModel.swift
@@ -163,10 +163,11 @@ public final class BeverageRecordViewModel: ViewModelable {
       guard let selectedSize = state.selectedSizeType else {
         throw BeverageRecordError.noSizeSelected
       }
+      let recordDateWithCurrentTime = updateDateWithCurrentTime(state.beverageRecordDate)
       
       let success = try await beverageUseCase.recordBeverage(
         productID: state.productID,
-        recordDate: state.beverageRecordDate,
+        recordDate: recordDateWithCurrentTime,
         size: selectedSize.sizeType.uppercased()
       )
       
@@ -180,5 +181,21 @@ public final class BeverageRecordViewModel: ViewModelable {
     } catch {
       print("음료 기록 에러: \(error)")
     }
+  }
+  
+  private func updateDateWithCurrentTime(_ date: Date) -> Date {
+    let calendar = Calendar.current
+    let now = Date()
+    let dateComponents = calendar.dateComponents([.year, .month, .day], from: date)
+    let timeComponents = calendar.dateComponents([.hour, .minute, .second], from: now)
+    var newComponents = DateComponents()
+    newComponents.year = dateComponents.year
+    newComponents.month = dateComponents.month
+    newComponents.day = dateComponents.day
+    newComponents.hour = timeComponents.hour
+    newComponents.minute = timeComponents.minute
+    newComponents.second = timeComponents.second
+    
+    return calendar.date(from: newComponents) ?? date
   }
 }

--- a/HumanNeverDie/Projects/Features/HistoryFeature/Sources/HistoryViewModel.swift
+++ b/HumanNeverDie/Projects/Features/HistoryFeature/Sources/HistoryViewModel.swift
@@ -22,7 +22,7 @@ public final class HistoryViewModel: ViewModelable {
     var isViewDidLoad: Bool = false
     
     var currentDate: Date = Date()
-    var selectedDate: Date? = Date.now
+    var selectedDate: Date? = Date()
     
     var selectedIntakeHistoryID: String = ""
     var selectedProductID: String = ""
@@ -88,6 +88,8 @@ public final class HistoryViewModel: ViewModelable {
   public func handleAction(_ action: Action) {
     switch action {
     case .onAppear:
+      state.selectedDate = Date.now
+ 
       guard !state.isViewDidLoad else { return }
       state.isViewDidLoad = true
       
@@ -103,6 +105,8 @@ public final class HistoryViewModel: ViewModelable {
       state.isBevarageDetailPresented = true
       
     case .loadHistoryForSelectedDate:
+      print("selectedDate:\(state.selectedDate)")
+      
       loadSelectedDateHistory()
       
     case .updateCurrentDate(let newDate):

--- a/HumanNeverDie/Projects/Features/HomeFeature/Sources/HomeViewModel.swift
+++ b/HumanNeverDie/Projects/Features/HomeFeature/Sources/HomeViewModel.swift
@@ -63,7 +63,9 @@ public final class HomeViewModel: ViewModelable {
   public func handleAction(_ action: Action) {
     switch action {
     case .onViewDidLoad:
+      //초기화
       state.selectedDate = Date.now
+      state.currentDate = Date.now
       
       guard !state.isViewDidLoad else { return }
       state.isViewDidLoad = true

--- a/HumanNeverDie/Projects/Features/HomeFeature/Sources/HomeViewModel.swift
+++ b/HumanNeverDie/Projects/Features/HomeFeature/Sources/HomeViewModel.swift
@@ -63,6 +63,8 @@ public final class HomeViewModel: ViewModelable {
   public func handleAction(_ action: Action) {
     switch action {
     case .onViewDidLoad:
+      state.selectedDate = Date.now
+      
       guard !state.isViewDidLoad else { return }
       state.isViewDidLoad = true
       

--- a/HumanNeverDie/Projects/Features/SettingFeature/Sources/StepsView/AccountInfoView.swift
+++ b/HumanNeverDie/Projects/Features/SettingFeature/Sources/StepsView/AccountInfoView.swift
@@ -173,7 +173,7 @@ extension AccountInfoView {
       contentActivitySection()
     }
     .padding(.horizontal, 20)
-    .padding(.top, 48)
+    .padding(.top, 10)
   }
   
   @ViewBuilder


### PR DESCRIPTION
## 🔗 관련 이슈
- Resolved: #106 

## 🛠️ 작업한 내용
1. UI 수정
    * 정보 관리 화면 padding 값 변경 (48 → 10)
2. 시간 관련
    * 시간 선택 단위: 1분 단위 → 5분 단위로 조정
    * 캘린더 초기화 시: 오늘 날짜가 기본으로 보이도록 수정
    * HomeViewModel 로딩 시: selectedDate, currentDate 값이 올바르게 초기화되도록 수정
3. 데이터 처리
    * 음료 기록 시 현재 시간 정보 누락으로 삭제 구분이 되지 않던 오류 수정
    * 설탕 계산 공식: 반올림 → 반내림으로 변경


## 📸 스크린샷(선택)
|    1    |   2   |
| :-------------: | :----------: |
|  |  |

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

