### PR TITLE
[Bug] QA 3차 수정

### DIFF
--- a/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/WebView/AMDWebURL.swift
+++ b/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/WebView/AMDWebURL.swift
@@ -9,6 +9,8 @@ import Foundation
 
 public enum AMDWebURL: String, CaseIterable {
   case addBeverageForm = "https://forms.gle/9sVcZGZRATALoCRZ6"
+  case addTermsOfUse = "https://telling-abrosaurus-7ba.notion.site/24d0d89bf00580b08fcad69f40cf98ae"
+  case addPrivacyPolicy = "https://telling-abrosaurus-7ba.notion.site/24d0d89bf00580dc8277f6fa24888796?pvs=74"
   
   public var url: URL? {
     return URL(string: self.rawValue)

--- a/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/WebView/AMDWebURL.swift
+++ b/HumanNeverDie/Projects/CommonFeature/CommonFeature/Sources/Views/WebView/AMDWebURL.swift
@@ -11,6 +11,7 @@ public enum AMDWebURL: String, CaseIterable {
   case addBeverageForm = "https://forms.gle/9sVcZGZRATALoCRZ6"
   case addTermsOfUse = "https://telling-abrosaurus-7ba.notion.site/24d0d89bf00580b08fcad69f40cf98ae"
   case addPrivacyPolicy = "https://telling-abrosaurus-7ba.notion.site/24d0d89bf00580dc8277f6fa24888796?pvs=74"
+  case addReviewLink = "https://apps.apple.com/app/id6748367287?action=write-review"
   
   public var url: URL? {
     return URL(string: self.rawValue)

--- a/HumanNeverDie/Projects/CommonFeature/DesignSystem/Sources/Components/AMDDatePicker/AMDDatePickerViewController.swift
+++ b/HumanNeverDie/Projects/CommonFeature/DesignSystem/Sources/Components/AMDDatePicker/AMDDatePickerViewController.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import UIKit
 
 private struct AMDDatePickerConstants {
-  fileprivate static let years = Array(1970...Date().year)
+  fileprivate static let years = Array(1930...Date().year)
   fileprivate static let months = Array(1...12)
   fileprivate static let amPmOptions = ["오전", "오후"]
   fileprivate static let hours12 = Array(1...12)
@@ -99,7 +99,7 @@ public final class AMDDatePickerViewController: UIViewController {
 private extension AMDDatePickerViewController {
   var availableYears: [Int] {
     if isAgeRestricted == true {
-      return Array(1970...maxSelectableYear)
+      return Array(1930...maxSelectableYear)
     }
     return AMDDatePickerConstants.years
   }
@@ -161,8 +161,8 @@ private extension AMDDatePickerViewController {
       return maxDate
     }
     
-    // 전달받은 날짜가 1970년보다 이전이면 최대 날짜 반환
-    let minDate = Calendar.current.date(from: DateComponents(year: 1970, month: 1, day: 1)) ?? Date()
+    // 전달받은 날짜가 1930년보다 이전이면 최대 날짜 반환
+    let minDate = Calendar.current.date(from: DateComponents(year: 1930, month: 1, day: 1)) ?? Date()
     if date < minDate {
       return maxDate
     }

--- a/HumanNeverDie/Projects/Features/HistoryFeature/Sources/HistoryViewModel.swift
+++ b/HumanNeverDie/Projects/Features/HistoryFeature/Sources/HistoryViewModel.swift
@@ -90,9 +90,13 @@ public final class HistoryViewModel: ViewModelable {
     case .onAppear:
       state.selectedDate = Date.now
  
-      guard !state.isViewDidLoad else { return }
-      state.isViewDidLoad = true
+      let needsReload = reloadDateHistory()
       
+      if state.isViewDidLoad && !needsReload {
+        return
+      }
+      
+      state.isViewDidLoad = true
       Task { await refreshData() }
       
     case .loadHistorDailyList, .datePickeronConfirm, .historyRefresh:
@@ -145,6 +149,15 @@ public final class HistoryViewModel: ViewModelable {
 }
 
 extension HistoryViewModel {
+  
+  func reloadDateHistory() -> Bool {
+    guard let selectedDate = state.selectedDate else { return false }
+    
+    let selectedDateString = Date.toDateMonthString(from: selectedDate)
+    let currentDateString = Date.toDateMonthString(from: state.currentDate)
+    
+    return selectedDateString != currentDateString
+  }
   
   func getSelectedDateString() -> String {
     if let selected = state.selectedDate {

--- a/HumanNeverDie/Projects/Features/SettingFeature/Sources/SettingModel.swift
+++ b/HumanNeverDie/Projects/Features/SettingFeature/Sources/SettingModel.swift
@@ -17,7 +17,8 @@ public enum SettingItem: String, CaseIterable, Hashable {
   case terms = "약관 및 정책"
   case logout = "로그아웃"
   case unsubscribe = "탈퇴하기"
-  
+  case termsOfUse = "이용약관"
+  case privacyPolicy = "개인정보처리방침"
   
   public var title: String {
     return rawValue

--- a/HumanNeverDie/Projects/Features/SettingFeature/Sources/SettingView.swift
+++ b/HumanNeverDie/Projects/Features/SettingFeature/Sources/SettingView.swift
@@ -136,10 +136,9 @@ extension SettingView {
   }
   
   private func openAppStoreReviewPage() {
-    let appID = "6748367287"
-    
-    if let url = URL(string: "https://apps.apple.com/app/id\(appID)?action=write-review") {
-      UIApplication.shared.open(url)
+  
+    if let reviewURL = AMDWebURL.addReviewLink.url {
+      UIApplication.shared.open(reviewURL)
     }
   }
   

--- a/HumanNeverDie/Projects/Features/SettingFeature/Sources/SettingView.swift
+++ b/HumanNeverDie/Projects/Features/SettingFeature/Sources/SettingView.swift
@@ -133,6 +133,8 @@ extension SettingView {
     case .unsubscribe:
       viewModel.handleAction(.unsubscribe)
       break
+    case .termsOfUse, .privacyPolicy:
+      break
     }
   }
   

--- a/HumanNeverDie/Projects/Features/SettingFeature/Sources/SettingView.swift
+++ b/HumanNeverDie/Projects/Features/SettingFeature/Sources/SettingView.swift
@@ -119,22 +119,27 @@ extension SettingView {
     case .notificationSetting:
       router.push(to: .SettingNotificationSetting(userID: viewModel.userID))
       
-    case .feedback: break
-      //앱스토어 리뷰이동
-      
+    case .feedback:
+      openAppStoreReviewPage()
     case .terms:
       router.push(to: .SettingTerms)
-      
     case .settingTitle:
       break
     case .logout:
       viewModel.handleAction(.logout)
-      break
     case .unsubscribe:
       viewModel.handleAction(.unsubscribe)
-      break
+
     case .termsOfUse, .privacyPolicy:
       break
+    }
+  }
+  
+  private func openAppStoreReviewPage() {
+    let appID = "6748367287"
+    
+    if let url = URL(string: "https://apps.apple.com/app/id\(appID)?action=write-review") {
+      UIApplication.shared.open(url)
     }
   }
   

--- a/HumanNeverDie/Projects/Features/SettingFeature/Sources/SettingView.swift
+++ b/HumanNeverDie/Projects/Features/SettingFeature/Sources/SettingView.swift
@@ -73,7 +73,7 @@ public struct SettingView: View {
       sectionDivider().padding(.vertical, 16)
       
       VStack(alignment: .leading, spacing:0) {
-        AppVersionRow(title: "앱 버전", value: "1.0.1") // 추후 appID발행 후 로직 개발진행
+        AppVersionRow(title: "앱 버전", value: Bundle.main.appVersion) 
       }.padding(.horizontal, 20)
       
       Spacer()

--- a/HumanNeverDie/Projects/Features/SettingFeature/Sources/SettingViewModel.swift
+++ b/HumanNeverDie/Projects/Features/SettingFeature/Sources/SettingViewModel.swift
@@ -207,3 +207,10 @@ extension SettingViewModel {
     return state.userInfo
   }
 }
+
+extension Bundle {
+  var appVersion: String {
+    infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
+  }
+}
+

--- a/HumanNeverDie/Projects/Features/SettingFeature/Sources/StepsView/TermsView.swift
+++ b/HumanNeverDie/Projects/Features/SettingFeature/Sources/StepsView/TermsView.swift
@@ -7,24 +7,31 @@
 
 import SwiftUI
 import CommonFeature
+import DesignSystem
 
 public struct TermsView: View {
   @State private var viewModel: TermsViewModel
   @Environment(Router.self) private var router
-
+  
   public init(viewModel: TermsViewModel) {
     self._viewModel = .init(initialValue: viewModel)
   }
-
+  
   public var body: some View {
     List {
       Section {
-        TermsRow(title: "이용약관") {
-          openURL("https://telling-abrosaurus-7ba.notion.site/24d0d89bf00580b08fcad69f40cf98ae")
+        TermsRow(title: SettingItem.termsOfUse.title) {
+          viewModel.handleAction(.openTerms(
+            title: SettingItem.termsOfUse.title,
+            url: AMDWebURL.addTermsOfUse
+          ))
         }
-
-        TermsRow(title: "개인정보처리방침") {
-          openURL("https://telling-abrosaurus-7ba.notion.site/24d0d89bf00580dc8277f6fa24888796?pvs=74")
+        
+        TermsRow(title: SettingItem.privacyPolicy.title) {
+          viewModel.handleAction(.openTerms(
+            title: SettingItem.privacyPolicy.title,
+            url: AMDWebURL.addPrivacyPolicy
+          ))
         }
       }.padding(.horizontal, 20)
     }.settingToolbar(item: .terms) {
@@ -32,34 +39,64 @@ public struct TermsView: View {
     }
     .listStyle(.plain)
     .listRowSeparator(.hidden)
+    .fullScreenCover(isPresented: $viewModel.state.isPresentedAddTermsWebView) {
+      if let url = viewModel.state.selectedURL {
+        VStack(spacing: 0) {
+          webViewNavigationBar
+          AMDWebView(url: url)
+        }
+        .ignoresSafeArea(edges: .bottom)
+      }
+    }
   }
   
-  private func openURL(_ urlString: String) {
-    guard let url = URL(string: urlString) else { return }
-    UIApplication.shared.open(url)
-  }
-}
-
-private struct TermsRow: View {
-  let title: String
-  let onTap: () -> Void
-
-  var body: some View {
-    HStack {
-      Text(title)
+  private var webViewNavigationBar: some View {
+    HStack(spacing: 0) {
+      Button {
+        viewModel.handleAction(.closeWebView)
+      } label: {
+        AMDImage.arrowLeft24.swiftUIImage
+      }
+      
+      Spacer()
+      
+      Text(viewModel.state.webViewTitle)
         .amdFont(.mediumRegular)
         .foregroundColor(.gray85)
-
+      
       Spacer()
-
-      Image(systemName: "chevron.right")
-        .foregroundColor(.gray40)
-        .font(.system(size: 16))
+      
+      Color.clear
+        .frame(width: 24, height: 24)
     }
-    .padding(.vertical, 15)
-    .contentShape(Rectangle())
-    .onTapGesture(perform: onTap)
-    .listRowSeparator(.hidden)
-    .listRowInsets(EdgeInsets())
+    .padding(.horizontal, 16)
+    .frame(height: 56)
+    .background(Color.white)
+    .padding(.top, 1)
   }
+  
+  private struct TermsRow: View {
+    let title: String
+    let onTap: () -> Void
+    
+    var body: some View {
+      HStack {
+        Text(title)
+          .amdFont(.mediumRegular)
+          .foregroundColor(.gray85)
+        
+        Spacer()
+        
+        Image(systemName: "chevron.right")
+          .foregroundColor(.gray40)
+          .font(.system(size: 16))
+      }
+      .padding(.vertical, 15)
+      .contentShape(Rectangle())
+      .onTapGesture(perform: onTap)
+      .listRowSeparator(.hidden)
+      .listRowInsets(EdgeInsets())
+    }
+  }
+
 }

--- a/HumanNeverDie/Projects/Features/SettingFeature/Sources/StepsView/TermsViewModel.swift
+++ b/HumanNeverDie/Projects/Features/SettingFeature/Sources/StepsView/TermsViewModel.swift
@@ -15,10 +15,15 @@ import CommonFeature
 @MainActor
 public final class TermsViewModel: ViewModelable {
   public struct State: Equatable {
+    var isPresentedAddTermsWebView: Bool = false
+    var webViewTitle: String = ""
+    var selectedURL: URL?
   }
   
   public enum Action {
     case onAppear
+    case openTerms(title: String, url: AMDWebURL)
+    case closeWebView
   }
   
   public var state: State = .init()
@@ -28,6 +33,12 @@ public final class TermsViewModel: ViewModelable {
     switch action {
     case .onAppear:
       break
+    case .openTerms(let title, let url):
+      state.webViewTitle = title
+      state.selectedURL = url.url
+      state.isPresentedAddTermsWebView = true
+    case .closeWebView:
+      state.isPresentedAddTermsWebView = false
     }
   }
 }

--- a/HumanNeverDie/Projects/Shared/Shared/Sources/Extensions/Date+.swift
+++ b/HumanNeverDie/Projects/Shared/Shared/Sources/Extensions/Date+.swift
@@ -8,6 +8,14 @@
 import Foundation
 
 extension Date {
+  public static func toDateMonthString(from date: Date) -> String {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "ko_KR")
+    formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+    formatter.dateFormat = "yyyy-MM"
+    return formatter.string(from: date)
+  }
+  
   public static func toDateKeyString(from date: Date) -> String {
     let formatter = DateFormatter()
     formatter.locale = Locale(identifier: "ko_KR")


### PR DESCRIPTION
## 🔗 관련 이슈
- Resolved: #112 

## 🛠️ 작업한 내용
- 달력 기준 연도 1970 → 1930으로 변경
- 탭 전환 후 날짜 히스토리 갱신 안되는 문제 수정
- Safari 스타일 전체 화면 웹뷰 구현 (sheet → fullScreenCover)
- 앱스토어 리뷰 기능 추가
- 앱 버전 자동 표시 기능 추가

## 📸 스크린샷(선택)


## 🚨 참고 사항
현재 서버의 당류 계산공식 관련 API를 받지 못해 대기 중입니다.

